### PR TITLE
Root process arguments available for configuration remotely

### DIFF
--- a/containerm/things/datatypes_container_configuration.go
+++ b/containerm/things/datatypes_container_configuration.go
@@ -17,6 +17,7 @@ type configuration struct {
 	DomainName  string        `json:"domainName,omitempty"`
 	MountPoints []*mountPoint `json:"mountPoints,omitempty"`
 	Env         []string      `json:"env,omitempty"`
+	Cmd         []string      `json:"cmd,omitempty"`
 	// host resources
 	Devices       []*device      `json:"devices,omitempty"`
 	Privileged    bool           `json:"privileged,omitempty"`
@@ -76,6 +77,9 @@ func fromAPIContainerConfig(ctr *types.Container) *configuration {
 		if ctr.Config.Env != nil && len(ctr.Config.Env) > 0 {
 			cfg.Env = ctr.Config.Env
 		}
+		if ctr.Config.Cmd != nil && len(ctr.Config.Cmd) > 0 {
+			cfg.Cmd = ctr.Config.Cmd
+		}
 	}
 	return cfg
 }
@@ -126,9 +130,13 @@ func toAPIContainerConfig(cfg *configuration) *types.Container {
 	if cfg.Resources != nil {
 		ctr.HostConfig.Resources = toAPIResources(cfg.Resources)
 	}
-	if cfg.Env != nil && len(cfg.Env) > 0 {
-		ctr.Config = &types.ContainerConfiguration{
-			Env: cfg.Env,
+	if (cfg.Env != nil && len(cfg.Env) > 0) || (cfg.Cmd != nil && len(cfg.Cmd) > 0) {
+		ctr.Config = &types.ContainerConfiguration{}
+		if cfg.Env != nil && len(cfg.Env) > 0 {
+			ctr.Config.Env = cfg.Env
+		}
+		if cfg.Cmd != nil && len(cfg.Cmd) > 0 {
+			ctr.Config.Cmd = cfg.Cmd
 		}
 	}
 	return ctr

--- a/containerm/things/datatypes_container_configuration.go
+++ b/containerm/things/datatypes_container_configuration.go
@@ -131,12 +131,9 @@ func toAPIContainerConfig(cfg *configuration) *types.Container {
 		ctr.HostConfig.Resources = toAPIResources(cfg.Resources)
 	}
 	if (cfg.Env != nil && len(cfg.Env) > 0) || (cfg.Cmd != nil && len(cfg.Cmd) > 0) {
-		ctr.Config = &types.ContainerConfiguration{}
-		if cfg.Env != nil && len(cfg.Env) > 0 {
-			ctr.Config.Env = cfg.Env
-		}
-		if cfg.Cmd != nil && len(cfg.Cmd) > 0 {
-			ctr.Config.Cmd = cfg.Cmd
+		ctr.Config = &types.ContainerConfiguration{
+			Env: cfg.Env,
+			Cmd: cfg.Cmd,
 		}
 	}
 	return ctr

--- a/containerm/things/datatypes_container_configuration_test.go
+++ b/containerm/things/datatypes_container_configuration_test.go
@@ -26,6 +26,7 @@ const (
 	domain               = "domain"
 	host                 = "host"
 	env                  = "test-env"
+	cmd                  = "test-cmd"
 	mountSrc             = "/proc"
 	mountDest            = "/proc"
 	mountPropagationMode = string(types.RPrivatePropagationMode)
@@ -61,6 +62,7 @@ var (
 		PropagationMode: mountPropagationMode,
 	}}
 	envVar               = []string{env}
+	cmdVar               = []string{cmd}
 	hostConfigExtraHosts = []string{"ctrhost:host_ip"}
 	internalHostConfig   = &types.HostConfig{
 		Privileged:  hostConfigPrivileged,
@@ -112,6 +114,7 @@ var (
 
 	internalContainerConfig = &types.ContainerConfiguration{
 		Env: envVar,
+		Cmd: cmdVar,
 	}
 )
 
@@ -168,6 +171,9 @@ func TestFromAPIContainerConfig(t *testing.T) {
 	t.Run("test_from_api_container_config_env", func(t *testing.T) {
 		testutil.AssertEqual(t, ctr.Config.Env, ctrParsed.Env)
 	})
+	t.Run("test_from_api_container_config_cmd", func(t *testing.T) {
+		testutil.AssertEqual(t, ctr.Config.Cmd, ctrParsed.Cmd)
+	})
 	t.Run("test_from_api_container_config_resources", func(t *testing.T) {
 		testutil.AssertEqual(t, ctr.HostConfig.Resources, toAPIResources(ctrParsed.Resources))
 	})
@@ -182,6 +188,7 @@ var (
 			PropagationMode: rprivate,
 		}},
 		Env:        envVar,
+		Cmd:        cmdVar,
 		Devices:    []*device{{}},
 		Privileged: hostConfigPrivileged,
 		RestartPolicy: &restartPolicy{
@@ -248,6 +255,9 @@ func TestToAPIContainerConfig(t *testing.T) {
 	})
 	t.Run("test_to_api_container_config_env", func(t *testing.T) {
 		testutil.AssertEqual(t, testContainerConfig.Env, ctrParsed.Config.Env)
+	})
+	t.Run("test_to_api_container_config_cmd", func(t *testing.T) {
+		testutil.AssertEqual(t, testContainerConfig.Cmd, ctrParsed.Config.Cmd)
 	})
 	t.Run("test_to_api_container_config_resources", func(t *testing.T) {
 		testutil.AssertEqual(t, testContainerConfig.Resources, fromAPIResources(ctrParsed.HostConfig.Resources))

--- a/containerm/things/features_container.go
+++ b/containerm/things/features_container.go
@@ -27,7 +27,7 @@ import (
 const (
 	containerFeatureIDPrefix                 = "Container:"
 	containerFeatureIDTemplate               = containerFeatureIDPrefix + "%s"
-	containerFeatureDefinition               = "com.bosch.iot.suite.edge.containers:Container:1.3.0"
+	containerFeatureDefinition               = "com.bosch.iot.suite.edge.containers:Container:1.4.0"
 	containerFeaturePropertyStatus           = "status"
 	containerFeaturePropertyPathStatusState  = containerFeaturePropertyStatus + "/state"
 	containerFeaturePropertyPathStatusName   = containerFeaturePropertyStatus + "/name"

--- a/containerm/things/features_container_factory.go
+++ b/containerm/things/features_container_factory.go
@@ -29,7 +29,7 @@ const (
 	// ContainerFactoryFeatureID is the feature ID of the container factory
 	ContainerFactoryFeatureID = "ContainerFactory"
 	// containerFactoryFeatureDefinition is the feature definition of the container factory
-	containerFactoryFeatureDefinition = "com.bosch.iot.suite.edge.containers:ContainerFactory:1.1.0"
+	containerFactoryFeatureDefinition = "com.bosch.iot.suite.edge.containers:ContainerFactory:1.2.0"
 	// containerFactoryFeatureOperationCreate is the name of the operation that the feature implements
 	// based on the Vorto model provided in the feature's definition of the create operation
 	containerFactoryFeatureOperationCreate = "create"


### PR DESCRIPTION
[#6] The root process arguments per container are now available for configuration via the Ditto API.

Signed-off-by: Ognian Baruh <Ognyan.Baruh@bosch.io>