### PR TITLE
Improve container's environment variables

### DIFF
--- a/containerm/cli/cli_command_ctrs_get_info_test.go
+++ b/containerm/cli/cli_command_ctrs_get_info_test.go
@@ -85,14 +85,14 @@ func (getInfoTc *getInfoCommandTest) commandConfigDefault() interface{} {
 	}
 }
 
-func (getInfoTc *getInfoCommandTest) prepareCommand(flagsCfg map[string]string) {
+func (getInfoTc *getInfoCommandTest) prepareCommand(flagsCfg map[string]string) error {
 	// setup command to test
 	cmd := &getCtrInfoCmd{}
 	getInfoTc.getInfoCmd, getInfoTc.baseCmd = cmd, cmd
 
 	getInfoTc.getInfoCmd.init(getInfoTc.mockRootCommand)
 	// setup command flags
-	setCmdFlags(flagsCfg, getInfoTc.getInfoCmd.cmd)
+	return setCmdFlags(flagsCfg, getInfoTc.getInfoCmd.cmd)
 }
 
 func (getInfoTc *getInfoCommandTest) runCommand(args []string) error {

--- a/containerm/cli/cli_command_ctrs_list_test.go
+++ b/containerm/cli/cli_command_ctrs_list_test.go
@@ -79,14 +79,14 @@ func (listTc *listCommandTest) commandConfigDefault() interface{} {
 		name: "",
 	}
 }
-func (listTc *listCommandTest) prepareCommand(flagsCfg map[string]string) {
+func (listTc *listCommandTest) prepareCommand(flagsCfg map[string]string) error {
 	// setup command to test
 	cmd := &listCmd{}
 	listTc.listCmd, listTc.baseCmd = cmd, cmd
 
 	listTc.listCmd.init(listTc.mockRootCommand)
 	// setup command flags
-	setCmdFlags(flagsCfg, listTc.listCmd.cmd)
+	return setCmdFlags(flagsCfg, listTc.listCmd.cmd)
 }
 
 func (listTc *listCommandTest) runCommand(args []string) error {

--- a/containerm/cli/cli_command_ctrs_remove_test.go
+++ b/containerm/cli/cli_command_ctrs_remove_test.go
@@ -90,14 +90,14 @@ func (rmTc *removeCommandTest) commandConfigDefault() interface{} {
 	}
 }
 
-func (rmTc *removeCommandTest) prepareCommand(flagsCfg map[string]string) {
+func (rmTc *removeCommandTest) prepareCommand(flagsCfg map[string]string) error {
 	// setup command to test
 	cmd := &removeCmd{}
 	rmTc.cmdRemove, rmTc.baseCmd = cmd, cmd
 
 	rmTc.cmdRemove.init(rmTc.mockRootCommand)
 	// setup command flags
-	setCmdFlags(flagsCfg, rmTc.cmdRemove.cmd)
+	return setCmdFlags(flagsCfg, rmTc.cmdRemove.cmd)
 }
 
 func (rmTc *removeCommandTest) runCommand(args []string) error {

--- a/containerm/cli/cli_command_ctrs_rename_test.go
+++ b/containerm/cli/cli_command_ctrs_rename_test.go
@@ -91,14 +91,14 @@ func (renameTc *renameCommandTest) commandConfigDefault() interface{} {
 	return renameConfig{}
 }
 
-func (renameTc *renameCommandTest) prepareCommand(flagsCfg map[string]string) {
+func (renameTc *renameCommandTest) prepareCommand(flagsCfg map[string]string) error {
 	// setup command to test
 	cmd := &renameCtrCmd{}
 	renameTc.renameCmd, renameTc.baseCmd = cmd, cmd
 
 	renameTc.renameCmd.init(renameTc.mockRootCommand)
 	// setup command flags
-	setCmdFlags(flagsCfg, renameTc.renameCmd.cmd)
+	return setCmdFlags(flagsCfg, renameTc.renameCmd.cmd)
 }
 
 func (renameTc *renameCommandTest) runCommand(args []string) error {

--- a/containerm/cli/cli_command_ctrs_start_test.go
+++ b/containerm/cli/cli_command_ctrs_start_test.go
@@ -95,14 +95,14 @@ func (startTc *startCommandTest) commandConfigDefault() interface{} {
 	}
 }
 
-func (startTc *startCommandTest) prepareCommand(flagsCfg map[string]string) {
+func (startTc *startCommandTest) prepareCommand(flagsCfg map[string]string) error {
 	// setup command to test
 	cmd := &startCmd{}
 	startTc.cmdStart, startTc.baseCmd = cmd, cmd
 
 	startTc.cmdStart.init(startTc.mockRootCommand)
 	// setup command flags
-	setCmdFlags(flagsCfg, startTc.cmdStart.cmd)
+	return setCmdFlags(flagsCfg, startTc.cmdStart.cmd)
 }
 
 func (startTc *startCommandTest) runCommand(args []string) error {

--- a/containerm/cli/cli_command_ctrs_stop_test.go
+++ b/containerm/cli/cli_command_ctrs_stop_test.go
@@ -109,14 +109,14 @@ func (stopTc *stopCommandTest) commandConfigDefault() interface{} {
 	}
 }
 
-func (stopTc *stopCommandTest) prepareCommand(flagsCfg map[string]string) {
+func (stopTc *stopCommandTest) prepareCommand(flagsCfg map[string]string) error {
 	// setup command to test
 	cmd := &stopCmd{}
 	stopTc.cmdStop, stopTc.baseCmd = cmd, cmd
 
 	stopTc.cmdStop.init(stopTc.mockRootCommand)
 	// setup command flags
-	setCmdFlags(flagsCfg, stopTc.cmdStop.cmd)
+	return setCmdFlags(flagsCfg, stopTc.cmdStop.cmd)
 }
 
 func (stopTc *stopCommandTest) runCommand(args []string) error {

--- a/containerm/cli/cli_command_ctrs_update_test.go
+++ b/containerm/cli/cli_command_ctrs_update_test.go
@@ -149,14 +149,14 @@ func (updateTc *updateCommandTest) commandConfigDefault() interface{} {
 	}
 }
 
-func (updateTc *updateCommandTest) prepareCommand(flagsCfg map[string]string) {
+func (updateTc *updateCommandTest) prepareCommand(flagsCfg map[string]string) error {
 	// setup command to test
 	cmd := &updateCmd{}
 	updateTc.updateCmd, updateTc.baseCmd = cmd, cmd
 
 	updateTc.updateCmd.init(updateTc.mockRootCommand)
 	// setup command flags
-	setCmdFlags(flagsCfg, updateTc.updateCmd.cmd)
+	return setCmdFlags(flagsCfg, updateTc.updateCmd.cmd)
 }
 
 func (updateTc *updateCommandTest) runCommand(args []string) error {

--- a/containerm/cli/cli_command_sys_info_test.go
+++ b/containerm/cli/cli_command_sys_info_test.go
@@ -38,14 +38,14 @@ type sysInfoCommandTest struct {
 	sysInfoCmd *sysInfoCmd
 }
 
-func (sysInfoTc *sysInfoCommandTest) prepareCommand(flagsCfg map[string]string) {
+func (sysInfoTc *sysInfoCommandTest) prepareCommand(flagsCfg map[string]string) error {
 	// setup command to test
 	cmd := &sysInfoCmd{}
 	sysInfoTc.sysInfoCmd, sysInfoTc.baseCmd = cmd, cmd
 
 	sysInfoTc.sysInfoCmd.init(sysInfoTc.mockRootCommand)
 	// setup command flags
-	setCmdFlags(flagsCfg, sysInfoTc.sysInfoCmd.cmd)
+	return setCmdFlags(flagsCfg, sysInfoTc.sysInfoCmd.cmd)
 }
 
 func (sysInfoTc *sysInfoCommandTest) runCommand(args []string) error {

--- a/containerm/ctr/ctrd_container_create_opts.go
+++ b/containerm/ctr/ctrd_container_create_opts.go
@@ -90,15 +90,16 @@ func WithSnapshotOpts(snapshotID string, snapshotterType string) []containerd.Ne
 
 // WithSpecOpts sets the OCI specification configuration options for the container to be created.
 func WithSpecOpts(container *types.Container, image containerd.Image, execRoot string) containerd.NewContainerOpts {
-	var args []string
+	var args, env []string
 	if container.Config != nil {
 		args = container.Config.Cmd
+		env = container.Config.Env
 	}
 
 	return containerd.WithNewSpec(
 		ctrdoci.WithImageConfigArgs(image, args),
 		WithCommonOptions(container),
-		WithProcessOptions(container),
+		ctrdoci.WithEnv(env),
 		WithDevices(container),
 		WithMounts(container),
 		WithNamespaces(container),

--- a/containerm/ctr/ctrd_oci_linux.go
+++ b/containerm/ctr/ctrd_oci_linux.go
@@ -53,22 +53,6 @@ func WithCommonOptions(c *types.Container) crtdoci.SpecOpts {
 	}
 }
 
-// WithProcessOptions sets the container's root process configuration
-// - env variables
-// - etc.
-func WithProcessOptions(c *types.Container) crtdoci.SpecOpts {
-	return func(ctx context.Context, _ crtdoci.Client, _ *containers.Container, s *crtdoci.Spec) error {
-		if c.Config != nil && c.Config.Env != nil && len(c.Config.Env) > 0 {
-			//setup env hostname
-			if s.Process.Env == nil {
-				s.Process.Env = []string{}
-			}
-			s.Process.Env = append(s.Process.Env, c.Config.Env...)
-		}
-		return nil
-	}
-}
-
 // WithMounts sets the network resolution files generated
 //e.g. c.getRootResourceDir("resolv.conf"), "hostname", "hosts"
 func WithMounts(container *types.Container) crtdoci.SpecOpts {

--- a/containerm/util/containers_validation_test.go
+++ b/containerm/util/containers_validation_test.go
@@ -453,6 +453,36 @@ func TestNegativeContainerValidations(t *testing.T) {
 			},
 			expectedErr: log.NewErrorf("minimum memory allowed is 3M"),
 		},
+		"test_validate_config_env_incorrect_format_start_digit": {
+			ctr: &types.Container{
+				Image:      types.Image{Name: "image"},
+				HostConfig: &types.HostConfig{NetworkMode: types.NetworkModeBridge},
+				Config: &types.ContainerConfiguration{
+					Env: []string{"1VAR=1"},
+				},
+			},
+			expectedErr: log.NewErrorf("invalid environmental variable declaration provided : 1VAR=1"),
+		},
+		"test_validate_config_env_incorrect_format_start_other": {
+			ctr: &types.Container{
+				Image:      types.Image{Name: "image"},
+				HostConfig: &types.HostConfig{NetworkMode: types.NetworkModeBridge},
+				Config: &types.ContainerConfiguration{
+					Env: []string{"$VAR=1"},
+				},
+			},
+			expectedErr: log.NewErrorf("invalid environmental variable declaration provided : $VAR=1"),
+		},
+		"test_validate_config_env_incorrect_format_contains_bas_symbol": {
+			ctr: &types.Container{
+				Image:      types.Image{Name: "image"},
+				HostConfig: &types.HostConfig{NetworkMode: types.NetworkModeBridge},
+				Config: &types.ContainerConfiguration{
+					Env: []string{"V@R=1"},
+				},
+			},
+			expectedErr: log.NewErrorf("invalid environmental variable declaration provided : V@R=1"),
+		},
 	}
 
 	for testName, testCase := range tests {

--- a/containerm/util/util_base_test.go
+++ b/containerm/util/util_base_test.go
@@ -34,7 +34,12 @@ const (
 	hookTimeout = 10000
 	hookType    = internaltypes.HookTypePoststart
 
-	configEnv1 = "env1"
+	configEnv1 = "VAR1"
+	configEnv2 = "VAR2="
+	configEnv3 = "VAR3=test"
+	configEnv4 = "VAR4=\"test string\""
+	configEnv5 = "VAR5=test,comma"
+	configEnv6 = "_VAR6=test_underscore"
 
 	hostConfigPrivileged                 = true
 	hostConfigNetType                    = "bridge"
@@ -85,7 +90,7 @@ var (
 		Type:    hookType,
 	}}
 
-	configEnv               = []string{configEnv1}
+	configEnv               = []string{configEnv1, configEnv2, configEnv3, configEnv4, configEnv5, configEnv6}
 	internalContainerConfig = internaltypes.ContainerConfiguration{Env: configEnv}
 
 	hostConfigExtraHosts = []string{"ctrhost:host_ip"}


### PR DESCRIPTION
# 22
- accept VAR and VAR= as valid
- containerd's WithEnv is used, WithProcessOptions is removed
- move env validation to container validation
- added and adjusted env variable unit tests
- CLI unit tests changed to handle errors from setting cmd flags

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov3@bosch.io>