### PR TITLE
Support for cgroups v2

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -117,6 +117,12 @@ coreos/go-semver (0.3.0)
 * Project: https://github.com/coreos/go-semver
 * Source:  https://github.com/coreos/go-semver/releases/tag/v0.3.0
 
+coreos/go-systemd (22.3.2)
+
+* License: Apache License 2.0
+* Project: https://github.com/coreos/go-systemd
+* Source:  https://github.com/coreos/go-systemd/releases/tag/v22.3.2
+
 deckarep/golang-set (1.8.0)
 
 * License: MIT

--- a/containerm/containers/types/host_config.go
+++ b/containerm/containers/types/host_config.go
@@ -14,11 +14,25 @@ package types
 // NetworkMode represents the network mode for the container
 type NetworkMode string
 
+// Runtime represents the runtime for the container
+type Runtime string
+
 const (
 	// NetworkModeBridge means that the container is connected to the default bridge network interface of the engine and is assigned an IP
 	NetworkModeBridge NetworkMode = "bridge"
 	// NetworkModeHost means that the container shares the network stack of the host
 	NetworkModeHost NetworkMode = "host"
+
+	// RuntimeTypeV1 is the runtime type name for containerd shim interface v1 version.
+	RuntimeTypeV1 Runtime = "io.containerd.runtime.v1.linux"
+	// RuntimeTypeV2runscV1 is the runtime type name for gVisor containerd shim implement the shim v2 api.
+	RuntimeTypeV2runscV1 Runtime = "io.containerd.runsc.v1"
+	// RuntimeTypeV2kataV2 is the runtime type name for kata-runtime containerd shim implement the shim v2 api.
+	RuntimeTypeV2kataV2 Runtime = "io.containerd.kata.v2"
+	// RuntimeTypeV2runcV1 is the runtime type name for runc containerd shim implement the shim v2 api.
+	RuntimeTypeV2runcV1 Runtime = "io.containerd.runc.v1"
+	// RuntimeTypeV2runcV2 is the version 2 runtime type name for runc containerd shim implement the shim v2 api.
+	RuntimeTypeV2runcV2 Runtime = "io.containerd.runc.v2"
 )
 
 // HostConfig defines the resources, behavior, etc. that the host must manage on the container
@@ -27,7 +41,7 @@ type HostConfig struct {
 	NetworkMode   NetworkMode       `json:"network_mode"`
 	Privileged    bool              `json:"privileged"`
 	RestartPolicy *RestartPolicy    `json:"restart_policy"`
-	Runtime       string            `json:"runtime"`
+	Runtime       Runtime           `json:"runtime"`
 	ExtraHosts    []string          `json:"extra_hosts"`
 	PortMappings  []PortMapping     `json:"port_mappings"`
 	LogConfig     *LogConfiguration `json:"log_config"`

--- a/containerm/ctr/ctr_client_opts.go
+++ b/containerm/ctr/ctr_client_opts.go
@@ -11,6 +11,11 @@
 
 package ctr
 
+import (
+	"github.com/eclipse-kanto/container-management/containerm/containers/types"
+	"github.com/eclipse-kanto/container-management/containerm/log"
+)
+
 // ContainerOpts represents container engine client's configuration options.
 type ContainerOpts func(ctrOptions *ctrOpts) error
 
@@ -22,6 +27,7 @@ type ctrOpts struct {
 	metaPath           string
 	imageDecKeys       []string
 	imageDecRecipients []string
+	runcRuntime        types.Runtime
 }
 
 // RegistryConfig represents a single registry's access configuration.
@@ -105,6 +111,19 @@ func WithCtrdImageDecryptKeys(keys ...string) ContainerOpts {
 func WithCtrdImageDecryptRecipients(recipients ...string) ContainerOpts {
 	return func(ctrOptions *ctrOpts) error {
 		ctrOptions.imageDecRecipients = recipients
+		return nil
+	}
+}
+
+// WithCtrdRuncRuntime sets the container runcRuntime.
+func WithCtrdRuncRuntime(runcRuntime string) ContainerOpts {
+	return func(ctrOptions *ctrOpts) error {
+		switch types.Runtime(runcRuntime) {
+		case types.RuntimeTypeV1, types.RuntimeTypeV2runcV1, types.RuntimeTypeV2runcV2:
+			ctrOptions.runcRuntime = types.Runtime(runcRuntime)
+		default:
+			return log.NewErrorf("unexpected runc runtime = %s", runcRuntime)
+		}
 		return nil
 	}
 }

--- a/containerm/ctr/ctr_client_opts.go
+++ b/containerm/ctr/ctr_client_opts.go
@@ -115,7 +115,7 @@ func WithCtrdImageDecryptRecipients(recipients ...string) ContainerOpts {
 	}
 }
 
-// WithCtrdRuncRuntime sets the container runcRuntime.
+// WithCtrdRuncRuntime sets the container runc runtime.
 func WithCtrdRuncRuntime(runcRuntime string) ContainerOpts {
 	return func(ctrOptions *ctrOpts) error {
 		switch types.Runtime(runcRuntime) {

--- a/containerm/ctr/ctrd_client.go
+++ b/containerm/ctr/ctrd_client.go
@@ -49,6 +49,7 @@ type containerdClient struct {
 	decMgr             containerDecryptMgr
 	spi                containerdSpi
 	eventsCancel       context.CancelFunc
+	runcRuntime        types.Runtime
 }
 
 //-------------------------------------- ContainerdAPIClient implementation with Containerd -------------------------------------
@@ -201,6 +202,7 @@ func (ctrdClient *containerdClient) StartContainer(ctx context.Context, containe
 		return -1, err
 	}
 
+	ctrdClient.configureRuncRuntime(container)
 	createOpts, err = ctrdClient.generateNewContainerOpts(container, image)
 	if err != nil {
 		log.ErrorErr(err, "failed to generate create opts for image ID = %s for container with ID = %s", container.Image.Name, container.ID)

--- a/containerm/ctr/ctrd_client_internal.go
+++ b/containerm/ctr/ctrd_client_internal.go
@@ -78,6 +78,19 @@ func (ctrdClient *containerdClient) generateNewContainerOpts(container *types.Co
 	return createOpts, nil
 }
 
+func (ctrdClient *containerdClient) configureRuncRuntime(container *types.Container) {
+	if container.HostConfig.Runtime != ctrdClient.runcRuntime {
+		switch container.HostConfig.Runtime {
+		case types.RuntimeTypeV1, types.RuntimeTypeV2runcV1, types.RuntimeTypeV2runcV2:
+			log.Info("container runc runtime is automatically updated from %s to %s for container ID = %s", container.HostConfig.Runtime, ctrdClient.runcRuntime, container.ID)
+			container.HostConfig.Runtime = ctrdClient.runcRuntime
+		default:
+			// non runc runtime, must not change
+		}
+	}
+	log.Debug("container runtime = %s for container ID = %s", container.HostConfig.Runtime, container.ID)
+}
+
 func (ctrdClient *containerdClient) getImage(ctx context.Context, imageInfo types.Image) (containerd.Image, error) {
 	decryptConfig, err := ctrdClient.decMgr.GetDecryptConfig(imageInfo.DecryptConfig)
 	if err != nil {

--- a/containerm/daemon/daemon_command.go
+++ b/containerm/daemon/daemon_command.go
@@ -44,6 +44,7 @@ func setupCommandFlags(cmd *cobra.Command) {
 	flagSet.StringVar(&cfg.ContainerClientConfig.CtrMetaPath, "ccl-home-dir", cfg.ContainerClientConfig.CtrMetaPath, "Specify the home directory to be used for container runtime management data")
 	flagSet.StringSliceVar(&cfg.ContainerClientConfig.CtrImageDecKeys, "ccl-image-dec-keys", cfg.ContainerClientConfig.CtrImageDecKeys, "Specify a list of private keys filenames (GPG private key ring, JWE and PKCS7 private key). Each entry can include an optional password separated by a colon after the filename.")
 	flagSet.StringSliceVar(&cfg.ContainerClientConfig.CtrImageDecRecipients, "ccl-image-dec-recipients", cfg.ContainerClientConfig.CtrImageDecRecipients, "Specify a recipients certificates list of the image (used only for PKCS7 and must be an x509)")
+	flagSet.StringVar(&cfg.ContainerClientConfig.CtrRuncRuntime, "ccl-runc-runtime", cfg.ContainerClientConfig.CtrRuncRuntime, "Specify a default global runc runtime - possible values are io.containerd.runtime.v1.linux, io.containerd.runc.v1 and io.containerd.runc.v2. ")
 
 	// init network manager flags
 	flagSet.StringVar(&cfg.NetworkConfig.NetType, "net-type", cfg.NetworkConfig.NetType, "Specify the default network management type for containers")

--- a/containerm/daemon/daemon_config.go
+++ b/containerm/daemon/daemon_config.go
@@ -47,6 +47,7 @@ type containerRuntimeConfig struct {
 	CtrMetaPath           string                     `json:"home_dir,omitempty"`
 	CtrImageDecKeys       []string                   `json:"image_dec_keys,omitempty"`
 	CtrImageDecRecipients []string                   `json:"image_dec_recipients,omitempty"`
+	CtrRuncRuntime        string                     `json:"runc_runtime,omitempty"`
 }
 
 // registry config

--- a/containerm/daemon/daemon_config_default.go
+++ b/containerm/daemon/daemon_config_default.go
@@ -43,6 +43,7 @@ const (
 	containerClientAddressPathDefault = "/run/containerd/containerd.sock"
 	containerClientExecRootDefault    = managerExecRootPathDefault
 	containerClientMetaPathDefault    = managerMetaPathDefault
+	containerClientRuncRuntimeDefault = string(types.RuntimeTypeV2runcV2)
 
 	// default network manager config
 	networkManagerNetTypeDefault  = string(types.NetworkModeBridge)
@@ -112,6 +113,7 @@ func getDefaultInstance() *config {
 			CtrInsecureRegistries: containerClientInsecureRegistriesDefault,
 			CtrRootExec:           containerClientExecRootDefault,
 			CtrMetaPath:           containerClientMetaPathDefault,
+			CtrRuncRuntime:        containerClientRuncRuntimeDefault,
 		},
 		NetworkConfig: &networkConfig{
 			NetType:     networkManagerNetTypeDefault,

--- a/containerm/daemon/daemon_config_util.go
+++ b/containerm/daemon/daemon_config_util.go
@@ -13,6 +13,7 @@ package main
 
 import (
 	"encoding/json"
+	"github.com/eclipse-kanto/container-management/containerm/containers/types"
 	"io/ioutil"
 	"os"
 	"time"
@@ -38,6 +39,7 @@ func extractCtrClientConfigOptions(daemonConfig *config) []ctr.ContainerOpts {
 		ctr.WithCtrdRegistryConfigs(parseRegistryConfigs(daemonConfig.ContainerClientConfig.CtrRegistryConfigs, daemonConfig.ContainerClientConfig.CtrInsecureRegistries)),
 		ctr.WithCtrdImageDecryptKeys(daemonConfig.ContainerClientConfig.CtrImageDecKeys...),
 		ctr.WithCtrdImageDecryptRecipients(daemonConfig.ContainerClientConfig.CtrImageDecRecipients...),
+		ctr.WithCtrdRuncRuntime(daemonConfig.ContainerClientConfig.CtrRuncRuntime),
 	)
 	return ctrOpts
 }
@@ -206,6 +208,11 @@ func dumpContClient(configInstance *config) {
 		log.Debug("[daemon_cfg][ccl-home-dir] : %s", configInstance.ContainerClientConfig.CtrMetaPath)
 		log.Debug("[daemon_cfg][ccl-image-dec-keys] : %s", configInstance.ContainerClientConfig.CtrImageDecKeys)
 		log.Debug("[daemon_cfg][ccl-image-dec-recipients] : %s", configInstance.ContainerClientConfig.CtrImageDecRecipients)
+		r := types.Runtime(configInstance.ContainerClientConfig.CtrRuncRuntime)
+		log.Debug("[daemon_cfg][ccl-runc-runtime] : %s", r)
+		if r == types.RuntimeTypeV1 || r == types.RuntimeTypeV2runcV1 {
+			log.Warn("runtime %s is deprecated since containerd v1.4, consider using %s", r, types.RuntimeTypeV2runcV2)
+		}
 	}
 }
 

--- a/containerm/daemon/daemon_test.go
+++ b/containerm/daemon/daemon_test.go
@@ -238,6 +238,10 @@ func TestSetCommandFlags(t *testing.T) {
 			flag:         "ccl-image-dec-recipients",
 			expectedType: "stringSlice",
 		},
+		"test_flags_ccl-runc-runtime": {
+			flag:         "ccl-runc-runtime",
+			expectedType: reflect.String.String(),
+		},
 		"test_flags_net-type": {
 			flag:         "net-type",
 			expectedType: reflect.String.String(),

--- a/containerm/mgr/mgr.go
+++ b/containerm/mgr/mgr.go
@@ -475,7 +475,7 @@ func (mgr *containerMgr) Remove(ctx context.Context, id string, force bool) erro
 func (mgr *containerMgr) Dispose(ctx context.Context) error {
 	log.Debug("waiting for any container resources and operations to finish")
 	if err := mgr.stopManagerService(ctx); err != nil {
-		log.WarnErr(err, "error while stopping containers on sopping the container management service")
+		log.WarnErr(err, "error while stopping containers on stopping the container management service")
 	}
 	log.Debug("finished clearing container resources and operations")
 	var err error

--- a/containerm/pkg/testutil/config/daemon-config.json
+++ b/containerm/pkg/testutil/config/daemon-config.json
@@ -21,7 +21,8 @@
       "localhost"
     ],
     "exec_root_dir": "/var/run/container-management",
-    "home_dir": "/var/lib/container-management"
+    "home_dir": "/var/lib/container-management",
+    "runc_runtime": "io.containerd.runc.v2"
   },
   "network": {
     "type": "bridge",

--- a/containerm/util/containers.go
+++ b/containerm/util/containers.go
@@ -216,6 +216,12 @@ func FillDefaults(container *types.Container) bool {
 		changesMade = fillPortMappings(container) || changesMade
 	}
 
+	if container.HostConfig.Runtime == "" {
+		log.Debug("container's runtime is not set - setting a default one")
+		container.HostConfig.Runtime = types.RuntimeTypeV2runcV2
+		changesMade = true
+	}
+
 	if container.IOConfig == nil {
 		log.Debug("IO config is not set - setting it to default")
 		container.IOConfig = &types.IOConfig{

--- a/containerm/util/protobuf/convert_to_internal_util.go
+++ b/containerm/util/protobuf/convert_to_internal_util.go
@@ -214,7 +214,7 @@ func ToInternalHostConfig(grpcHostConfig *apitypescontainers.HostConfig) *intern
 		NetworkMode:   internaltypes.NetworkMode(grpcHostConfig.NetworkMode),
 		Privileged:    grpcHostConfig.Privileged,
 		RestartPolicy: ToInternalRestartPolicy(grpcHostConfig.RestartPolicy),
-		Runtime:       grpcHostConfig.Runtime,
+		Runtime:       internaltypes.Runtime(grpcHostConfig.Runtime),
 		ExtraHosts:    grpcHostConfig.ExtraHosts,
 		PortMappings:  ToInternalPortMappings(grpcHostConfig.PortMappings),
 		LogConfig:     ToInternalLogConfig(grpcHostConfig.LogConfig),

--- a/containerm/util/protobuf/convert_to_proto_util.go
+++ b/containerm/util/protobuf/convert_to_proto_util.go
@@ -243,7 +243,7 @@ func ToProtoHostConfig(internalHostConfig *internaltypes.HostConfig) *apitypesco
 		NetworkMode:   string(internalHostConfig.NetworkMode),
 		Privileged:    internalHostConfig.Privileged,
 		RestartPolicy: ToProtoRestartPolicy(internalHostConfig.RestartPolicy),
-		Runtime:       internalHostConfig.Runtime,
+		Runtime:       string(internalHostConfig.Runtime),
 		ExtraHosts:    internalHostConfig.ExtraHosts,
 		PortMappings:  ToProtoPortMappings(internalHostConfig.PortMappings),
 		LogConfig:     ToProtoLogConfig(internalHostConfig.LogConfig),

--- a/containerm/util/util_system.go
+++ b/containerm/util/util_system.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package util
+
+import (
+	"os"
+	"sync"
+)
+
+var (
+	runningSystemd bool
+	detectSystemd  sync.Once
+)
+
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package util contains utility functions related to systemd that applications
+// can use to check things like whether systemd is running.  Note that some of
+// these functions attempt to manually load systemd libraries at runtime rather
+// than linking against them.
+
+// IsRunningSystemd checks whether the host was booted with systemd as its init
+// system. This functions similarly to systemd's `sd_booted(3)`: internally, it
+// checks whether /run/systemd/system/ exists and is a directory.
+// http://www.freedesktop.org/software/systemd/man/sd_booted.html
+//
+// Package name changed also removed not needed logic and added custom code to handle the specific use case, Eclipse Kanto contributors, 2022
+func IsRunningSystemd() bool {
+	detectSystemd.Do(func() {
+		fi, err := os.Lstat("/run/systemd/system")
+		if err != nil {
+			return
+		}
+		runningSystemd = fi.IsDir()
+	})
+	return runningSystemd
+}


### PR DESCRIPTION
[#25] Support for cgroups v2
- use io.containerd.runc.v2 by default
- configurable runc runtime upon daemon start
- use systemd cgroup driver

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov3@bosch.io>