### PR TITLE
Install to /usr/bin

### DIFF
--- a/containerm/resources/container-management.service
+++ b/containerm/resources/container-management.service
@@ -7,7 +7,7 @@ Requires=containerd.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/container-management --cfg-file /etc/container-management/config.json
+ExecStart=/usr/bin/container-management --cfg-file /etc/container-management/config.json
 Restart=always
 TimeoutSec=300
 


### PR DESCRIPTION
[#39] Install to /usr/bin
libostree requires all binaries installed using rpm to be in `/usr/bin` rather than `/usr/local/bin`