### PR TITLE
Typo fixes in the API

### DIFF
--- a/containerm/mgr/mgr.go
+++ b/containerm/mgr/mgr.go
@@ -48,7 +48,7 @@ type containerMgr struct {
 	execPath               string
 	defaultCtrsStopTimeout int64
 	ctrClient              ctr.ContainerAPIClient
-	netMgr                 network.ConteinerNetworkManager
+	netMgr                 network.ContainerNetworkManager
 	eventsMgr              events.ContainerEventsManager
 
 	containers     map[string]*types.Container
@@ -236,8 +236,8 @@ func (mgr *containerMgr) Start(ctx context.Context, id string) error {
 	return mgr.processStartContainer(ctx, id, true)
 }
 
-// AttachContainer attaches the container's IO
-func (mgr *containerMgr) AttachContainer(ctx context.Context, id string, attachConfig *streams.AttachConfig) error {
+// Attach attaches the container's IO
+func (mgr *containerMgr) Attach(ctx context.Context, id string, attachConfig *streams.AttachConfig) error {
 	container := mgr.getContainerFromCache(id)
 	if container == nil {
 		return log.NewErrorf(noSuchContainerErrorMsg, id)

--- a/containerm/mgr/mgr_api.go
+++ b/containerm/mgr/mgr_api.go
@@ -39,8 +39,8 @@ type ContainerManager interface {
 	// Start starts a container that has been stopped or created
 	Start(ctx context.Context, id string) error
 
-	// AttachContainer attaches the container's IO
-	AttachContainer(ctx context.Context, id string, attachConfig *streams.AttachConfig) error
+	// Attach attaches the container's IO
+	Attach(ctx context.Context, id string, attachConfig *streams.AttachConfig) error
 
 	// Stop stops a running container
 	Stop(ctx context.Context, id string, stopOpts *types.StopOpts) error

--- a/containerm/mgr/mgr_internal_init.go
+++ b/containerm/mgr/mgr_internal_init.go
@@ -22,7 +22,7 @@ import (
 	"github.com/eclipse-kanto/container-management/containerm/util"
 )
 
-func newContainerMgr(metaPath string, execPath string, defaultCtrsStopTimeout int64, ctrClient ctr.ContainerAPIClient, netMgr network.ConteinerNetworkManager, eventsMgr events.ContainerEventsManager) (ContainerManager, error) {
+func newContainerMgr(metaPath string, execPath string, defaultCtrsStopTimeout int64, ctrClient ctr.ContainerAPIClient, netMgr network.ContainerNetworkManager, eventsMgr events.ContainerEventsManager) (ContainerManager, error) {
 	locksCache := util.NewLocksCache()
 	ctrRepository := containerFsRepository{metaPath: metaPath, locksCache: &locksCache}
 
@@ -86,6 +86,6 @@ func registryInit(registryCtx *registry.ServiceRegistryContext) (interface{}, er
 	}
 
 	//initialize the manager local service
-	return newContainerMgr(mgrOpts.metaPath, mgrOpts.rootExec, mgrOpts.defaultCtrsStopTimeout, ctrClientService.(ctr.ContainerAPIClient), netMgrService.(network.ConteinerNetworkManager), eventsManagerService.(events.ContainerEventsManager))
+	return newContainerMgr(mgrOpts.metaPath, mgrOpts.rootExec, mgrOpts.defaultCtrsStopTimeout, ctrClientService.(ctr.ContainerAPIClient), netMgrService.(network.ContainerNetworkManager), eventsManagerService.(events.ContainerEventsManager))
 
 }

--- a/containerm/mgr/mgr_test.go
+++ b/containerm/mgr/mgr_test.go
@@ -1052,7 +1052,7 @@ func TestAttach(t *testing.T) {
 	unitUnderTest.Load(ctx)
 
 	// Act
-	err := unitUnderTest.AttachContainer(context.Background(), ctrID, attachConfig)
+	err := unitUnderTest.Attach(context.Background(), ctrID, attachConfig)
 
 	testutil.AssertNil(t, err)
 }
@@ -1092,7 +1092,7 @@ func getStoppedContainer() (string, *types.Container) {
 func createContainerManagerWithCustomMocks(
 	metaPath string,
 	mockCtrClient ctr.ContainerAPIClient,
-	mockNetworkManager network.ConteinerNetworkManager,
+	mockNetworkManager network.ContainerNetworkManager,
 	mockEventsManager events.ContainerEventsManager,
 	mockRepository containerRepository,
 	containersCache map[string]*types.Container,

--- a/containerm/network/libnet_mgr_init.go
+++ b/containerm/network/libnet_mgr_init.go
@@ -15,7 +15,7 @@ import (
 	"github.com/eclipse-kanto/container-management/containerm/registry"
 )
 
-func newLibnetworkMgr(netConfig config) (ConteinerNetworkManager, error) {
+func newLibnetworkMgr(netConfig config) (ContainerNetworkManager, error) {
 	return &libnetworkMgr{&netConfig, nil}, nil
 }
 

--- a/containerm/network/libnet_mgr_test.go
+++ b/containerm/network/libnet_mgr_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
-type prepare func(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager
-type prepareInit func(gomockCtrl *gomock.Controller, config *config) ConteinerNetworkManager
+type prepare func(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager
+type prepareInit func(gomockCtrl *gomock.Controller, config *config) ContainerNetworkManager
 type assertContainer func(t *testing.T, mgrConfig *config, container *types.Container)
 
 const (
@@ -703,10 +703,10 @@ func assertConnectedContainer(t *testing.T, mgrConfig *config, container *types.
 	testutil.AssertEqual(t, mgrConfig.bridgeConfig.name, epSettings.NetworkID)
 }
 
-func prepareNilCtrl(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareNilCtrl(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	return &libnetworkMgr{config, nil}
 }
-func prepareDefault(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareDefault(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
 
@@ -714,7 +714,7 @@ func prepareDefault(gomockCtrl *gomock.Controller, config *config, container *ty
 	mockLibnetMgr.EXPECT().NewSandbox(container.ID, gomock.Any()).Times(1).Return(mockSb, nil)
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareDefaultExistingSb(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareDefaultExistingSb(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
 
@@ -732,7 +732,7 @@ func prepareDefaultExistingSb(gomockCtrl *gomock.Controller, config *config, con
 
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareDestrySbFailed(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareDestrySbFailed(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
 
@@ -750,7 +750,7 @@ func prepareDestrySbFailed(gomockCtrl *gomock.Controller, config *config, contai
 
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareNewSbFailed(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareNewSbFailed(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
 
@@ -760,13 +760,13 @@ func prepareNewSbFailed(gomockCtrl *gomock.Controller, config *config, container
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
 
-func prepareConnectErrorGettingNetwork(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareConnectErrorGettingNetwork(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 
 	mockLibnetMgr.EXPECT().NetworkByName(string(container.HostConfig.NetworkMode)).Times(1).Return(nil, log.NewErrorf("no network"))
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareConnectErrorGettingSb(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareConnectErrorGettingSb(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockNetwork := mocks.NewMockNetwork(gomockCtrl)
 
@@ -774,7 +774,7 @@ func prepareConnectErrorGettingSb(gomockCtrl *gomock.Controller, config *config,
 	mockLibnetMgr.EXPECT().WalkSandboxes(gomock.Any()).Times(1)
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareConnectErrorGettingEp(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareConnectErrorGettingEp(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockNetwork := mocks.NewMockNetwork(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
@@ -793,7 +793,7 @@ func prepareConnectErrorGettingEp(gomockCtrl *gomock.Controller, config *config,
 	mockNetwork.EXPECT().EndpointByID(container.NetworkSettings.Networks["bridge"].ID).Times(1).Return(nil, log.NewErrorf("no endpoint"))
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareConnectErrorGettingEpDelete(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareConnectErrorGettingEpDelete(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockNetwork := mocks.NewMockNetwork(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
@@ -814,7 +814,7 @@ func prepareConnectErrorGettingEpDelete(gomockCtrl *gomock.Controller, config *c
 	mockEp.EXPECT().Delete(true).Return(log.NewErrorf("error deleting endpoint")).Times(1)
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareConnectErrorJoiningEp(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareConnectErrorJoiningEp(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockNetwork := mocks.NewMockNetwork(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
@@ -838,7 +838,7 @@ func prepareConnectErrorJoiningEp(gomockCtrl *gomock.Controller, config *config,
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
 
-func prepareConnectFullNoCtrNetworks(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareConnectFullNoCtrNetworks(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockNetwork := mocks.NewMockNetwork(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
@@ -878,7 +878,7 @@ func prepareConnectFullNoCtrNetworks(gomockCtrl *gomock.Controller, config *conf
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
 
-func prepareConnectFullWithOtherCtrNetworks(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareConnectFullWithOtherCtrNetworks(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockNetwork := mocks.NewMockNetwork(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
@@ -919,7 +919,7 @@ func prepareConnectFullWithOtherCtrNetworks(gomockCtrl *gomock.Controller, confi
 
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareConnectFullWithNetSettings(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareConnectFullWithNetSettings(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockNetwork := mocks.NewMockNetwork(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
@@ -957,7 +957,7 @@ func prepareConnectFullWithNetSettings(gomockCtrl *gomock.Controller, config *co
 
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareConnectErrorCreatingEp(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareConnectErrorCreatingEp(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockNetwork := mocks.NewMockNetwork(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
@@ -977,7 +977,7 @@ func prepareConnectErrorCreatingEp(gomockCtrl *gomock.Controller, config *config
 	mockNetwork.EXPECT().CreateEndpoint(container.ID+"-ep", gomock.Any()).Times(1).Return(nil, log.NewErrorf("error creating endpoint"))
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareInitNoSbs(gomockCtrl *gomock.Controller, config *config) ConteinerNetworkManager {
+func prepareInitNoSbs(gomockCtrl *gomock.Controller, config *config) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockNetwork := mocks.NewMockNetwork(gomockCtrl)
 
@@ -992,7 +992,7 @@ func prepareInitNoSbs(gomockCtrl *gomock.Controller, config *config) ConteinerNe
 
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareInitNoSbsErrorDeletingOldBridge(gomockCtrl *gomock.Controller, config *config) ConteinerNetworkManager {
+func prepareInitNoSbsErrorDeletingOldBridge(gomockCtrl *gomock.Controller, config *config) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockNetwork := mocks.NewMockNetwork(gomockCtrl)
 
@@ -1004,7 +1004,7 @@ func prepareInitNoSbsErrorDeletingOldBridge(gomockCtrl *gomock.Controller, confi
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
 
-func prepareInitNoSbsErrorDeletingNewBridge(gomockCtrl *gomock.Controller, config *config) ConteinerNetworkManager {
+func prepareInitNoSbsErrorDeletingNewBridge(gomockCtrl *gomock.Controller, config *config) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockNetwork := mocks.NewMockNetwork(gomockCtrl)
 
@@ -1018,7 +1018,7 @@ func prepareInitNoSbsErrorDeletingNewBridge(gomockCtrl *gomock.Controller, confi
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
 
-func prepareInitNoSbsErrorCreatingNewBridge(gomockCtrl *gomock.Controller, config *config) ConteinerNetworkManager {
+func prepareInitNoSbsErrorCreatingNewBridge(gomockCtrl *gomock.Controller, config *config) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockNetwork := mocks.NewMockNetwork(gomockCtrl)
 
@@ -1033,7 +1033,7 @@ func prepareInitNoSbsErrorCreatingNewBridge(gomockCtrl *gomock.Controller, confi
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
 
-func prepareInitNoSbsNoExistingHostNet(gomockCtrl *gomock.Controller, config *config) ConteinerNetworkManager {
+func prepareInitNoSbsNoExistingHostNet(gomockCtrl *gomock.Controller, config *config) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockNetwork := mocks.NewMockNetwork(gomockCtrl)
 
@@ -1049,7 +1049,7 @@ func prepareInitNoSbsNoExistingHostNet(gomockCtrl *gomock.Controller, config *co
 
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareInitWithSbs(gomockCtrl *gomock.Controller, config *config) ConteinerNetworkManager {
+func prepareInitWithSbs(gomockCtrl *gomock.Controller, config *config) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockNetwork := mocks.NewMockNetwork(gomockCtrl)
 
@@ -1061,7 +1061,7 @@ func prepareInitWithSbs(gomockCtrl *gomock.Controller, config *config) Conteiner
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
 
-func prepareInitWithSbsDefaultBridgeError(gomockCtrl *gomock.Controller, config *config) ConteinerNetworkManager {
+func prepareInitWithSbsDefaultBridgeError(gomockCtrl *gomock.Controller, config *config) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockNetwork := mocks.NewMockNetwork(gomockCtrl)
 
@@ -1072,17 +1072,17 @@ func prepareInitWithSbsDefaultBridgeError(gomockCtrl *gomock.Controller, config 
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
 
-func prepareInitHostNetFail(gomockCtrl *gomock.Controller, config *config) ConteinerNetworkManager {
+func prepareInitHostNetFail(gomockCtrl *gomock.Controller, config *config) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockLibnetMgr.EXPECT().NetworkByName(hostNetworkName).Times(1).Return(nil, nil)
 	mockLibnetMgr.EXPECT().NewNetwork(libnetworkDriverHost, hostNetworkName, "", gomock.Any()).Return(nil, log.NewErrorf("no host net"))
 
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareReleaseResourcesNilSettings(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareReleaseResourcesNilSettings(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	return &libnetworkMgr{config, nil}
 }
-func prepareReleaseResourcesFull(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareReleaseResourcesFull(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
 	mockEp := mocks.NewMockEndpoint(gomockCtrl)
@@ -1099,7 +1099,7 @@ func prepareReleaseResourcesFull(gomockCtrl *gomock.Controller, config *config, 
 
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareReleaseResourcesGetSbErr(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareReleaseResourcesGetSbErr(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 
 	mockLibnetMgr.EXPECT().SandboxByID(container.NetworkSettings.SandboxID).Return(nil, log.NewError("error getting sandbox")).Times(1)
@@ -1107,14 +1107,14 @@ func prepareReleaseResourcesGetSbErr(gomockCtrl *gomock.Controller, config *conf
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
 
-func prepareReleaseResourcesSbNil(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareReleaseResourcesSbNil(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 
 	mockLibnetMgr.EXPECT().SandboxByID(container.NetworkSettings.SandboxID).Return(nil, nil).Times(1)
 
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareReleaseResourcesEpsNil(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareReleaseResourcesEpsNil(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
 
@@ -1124,7 +1124,7 @@ func prepareReleaseResourcesEpsNil(gomockCtrl *gomock.Controller, config *config
 
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareReleaseResourcesMissingEp(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareReleaseResourcesMissingEp(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
 	mockEp := mocks.NewMockEndpoint(gomockCtrl)
@@ -1136,7 +1136,7 @@ func prepareReleaseResourcesMissingEp(gomockCtrl *gomock.Controller, config *con
 
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareReleaseResourcesEpLeaveSbError(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareReleaseResourcesEpLeaveSbError(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
 	mockEp := mocks.NewMockEndpoint(gomockCtrl)
@@ -1150,7 +1150,7 @@ func prepareReleaseResourcesEpLeaveSbError(gomockCtrl *gomock.Controller, config
 
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareReleaseResourcesEpDeleteError(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareReleaseResourcesEpDeleteError(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
 	mockEp := mocks.NewMockEndpoint(gomockCtrl)
@@ -1164,7 +1164,7 @@ func prepareReleaseResourcesEpDeleteError(gomockCtrl *gomock.Controller, config 
 
 	return &libnetworkMgr{config, mockLibnetMgr}
 }
-func prepareReleaseResourcesSbDeleteError(gomockCtrl *gomock.Controller, config *config, container *types.Container) ConteinerNetworkManager {
+func prepareReleaseResourcesSbDeleteError(gomockCtrl *gomock.Controller, config *config, container *types.Container) ContainerNetworkManager {
 	mockLibnetMgr := mocks.NewMockNetworkController(gomockCtrl)
 	mockSb := mocks.NewMockSandbox(gomockCtrl)
 	mockEp := mocks.NewMockEndpoint(gomockCtrl)

--- a/containerm/network/net_mgr_api.go
+++ b/containerm/network/net_mgr_api.go
@@ -17,8 +17,8 @@ import (
 	"github.com/eclipse-kanto/container-management/containerm/containers/types"
 )
 
-// ConteinerNetworkManager  abstracts container's network operations
-type ConteinerNetworkManager interface {
+// ContainerNetworkManager  abstracts container's network operations
+type ContainerNetworkManager interface {
 	// Manage performs any container network initialization operations that are needed so that a container is connectable afterwards
 	Manage(ctx context.Context, container *types.Container) error
 
@@ -28,7 +28,7 @@ type ConteinerNetworkManager interface {
 	// Disconnect disconnects the given container from given network
 	Disconnect(ctx context.Context, container *types.Container, force bool) error
 
-	// ReleaseContainerResources releases all locally allocated resources for the container by the network manager implementation - e.g. network endpoints, etc.
+	// ReleaseNetworkResources releases all locally allocated resources for the container by the network manager implementation - e.g. network endpoints, etc.
 	ReleaseNetworkResources(ctx context.Context, container *types.Container) error
 
 	// Dispose manages stop and dispose of the network manager

--- a/containerm/pkg/testutil/mocks/mgr/mock_mgr_api.go
+++ b/containerm/pkg/testutil/mocks/mgr/mock_mgr_api.go
@@ -47,18 +47,18 @@ func (m *MockContainerManager) EXPECT() *MockContainerManagerMockRecorder {
 	return m.recorder
 }
 
-// AttachContainer mocks base method.
-func (m *MockContainerManager) AttachContainer(arg0 context.Context, arg1 string, arg2 *streams.AttachConfig) error {
+// Attach mocks base method.
+func (m *MockContainerManager) Attach(arg0 context.Context, arg1 string, arg2 *streams.AttachConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AttachContainer", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Attach", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AttachContainer indicates an expected call of AttachContainer.
-func (mr *MockContainerManagerMockRecorder) AttachContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
+// Attach indicates an expected call of AttachContainer.
+func (mr *MockContainerManagerMockRecorder) Attach(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachContainer", reflect.TypeOf((*MockContainerManager)(nil).AttachContainer), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Attach", reflect.TypeOf((*MockContainerManager)(nil).Attach), arg0, arg1, arg2)
 }
 
 // Create mocks base method.

--- a/containerm/services/grpc_containers_service.go
+++ b/containerm/services/grpc_containers_service.go
@@ -111,7 +111,7 @@ func (server *containers) Attach(attachServer pbcontainers.Containers_AttachServ
 	attach.UseStderr = true
 	attach.Stderr = writer
 
-	if err := server.mgr.AttachContainer(ctx, ctrID, attach); err != nil {
+	if err := server.mgr.Attach(ctx, ctrID, attach); err != nil {
 		writer.Write([]byte(err.Error() + "\r\n"))
 		return err
 	}


### PR DESCRIPTION
#40
- network.ConteinerNetworkManager fixed to network.ContainerNetworkManager
- mgr.ContainerManager.AttachContainer fixed to mgr.ContainerManager.Attach

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov3@bosch.io>