### PR TITLE
Make the container management lease ID configurable

### DIFF
--- a/containerm/ctr/ctr_client_opts.go
+++ b/containerm/ctr/ctr_client_opts.go
@@ -31,6 +31,7 @@ type ctrOpts struct {
 	runcRuntime        types.Runtime
 	imageExpiry        time.Duration
 	imageExpiryDisable bool
+	leaseID            string
 }
 
 // RegistryConfig represents a single registry's access configuration.
@@ -143,6 +144,14 @@ func WithCtrdImageExpiry(expiry time.Duration) ContainerOpts {
 func WithCtrdImageExpiryDisable(disable bool) ContainerOpts {
 	return func(ctrOptions *ctrOpts) error {
 		ctrOptions.imageExpiryDisable = disable
+		return nil
+	}
+}
+
+// WithCtrdLeaseID sets the lease that the container client instance will use within containerd.
+func WithCtrdLeaseID(leaseID string) ContainerOpts {
+	return func(ctrOptions *ctrOpts) error {
+		ctrOptions.leaseID = leaseID
 		return nil
 	}
 }

--- a/containerm/ctr/ctr_client_opts_test.go
+++ b/containerm/ctr/ctr_client_opts_test.go
@@ -30,6 +30,7 @@ const (
 	testPass               = "test-pass"
 	testImageExpiry        = 31 * 24 * time.Hour
 	testImageExpiryDisable = true
+	testLeaseID            = "test-lease-id"
 )
 
 var (
@@ -53,6 +54,7 @@ var (
 		runcRuntime:        types.RuntimeTypeV2runcV2,
 		imageExpiry:        testImageExpiry,
 		imageExpiryDisable: testImageExpiryDisable,
+		leaseID:            testLeaseID,
 	}
 )
 
@@ -79,7 +81,8 @@ func TestCtrOpts(t *testing.T) {
 				WithCtrdImageDecryptRecipients(testDecRecipients...),
 				WithCtrdRuncRuntime(string(types.RuntimeTypeV2runcV2)),
 				WithCtrdImageExpiry(testImageExpiry),
-				WithCtrdImageExpiryDisable(testImageExpiryDisable)},
+				WithCtrdImageExpiryDisable(testImageExpiryDisable),
+				WithCtrdLeaseID(testLeaseID)},
 			expectedOpts: testOpt,
 		},
 	}

--- a/containerm/ctr/ctrd_client_init.go
+++ b/containerm/ctr/ctrd_client_init.go
@@ -23,7 +23,7 @@ import (
 	"github.com/eclipse-kanto/container-management/containerm/util"
 )
 
-func newContainerdClient(namespace, socket, rootExec, metaPath string, registryConfigs map[string]*RegistryConfig, imageDecKeys, imageDecRecipients []string, runcRuntime types.Runtime, imageExpiry time.Duration, imageExpiryDisable bool) (ContainerAPIClient, error) {
+func newContainerdClient(namespace, socket, rootExec, metaPath string, registryConfigs map[string]*RegistryConfig, imageDecKeys, imageDecRecipients []string, runcRuntime types.Runtime, imageExpiry time.Duration, imageExpiryDisable bool, leaseID string) (ContainerAPIClient, error) {
 
 	//ensure storage
 	err := util.MkDir(rootExec)
@@ -36,9 +36,9 @@ func newContainerdClient(namespace, socket, rootExec, metaPath string, registryC
 	}
 
 	log.Debug("starting container client with default namespace = %s", namespace)
-	ctrdClientSpi, err := newContainerdSpi(socket, namespace, containerd.DefaultSnapshotter /*overlayfs for now - TODO add client config*/, metaPath)
-	if err != nil {
-		return nil, err
+	ctrdClientSpi, spiErr := newContainerdSpi(socket, namespace, containerd.DefaultSnapshotter /*overlayfs for now - TODO add client config*/, metaPath, leaseID)
+	if spiErr != nil {
+		return nil, spiErr
 	}
 	decryptMgr, decrErr := newContainerDecryptManager(imageDecKeys, imageDecRecipients)
 	if decrErr != nil {
@@ -77,5 +77,5 @@ func registryInit(registryCtx *registry.ServiceRegistryContext) (interface{}, er
 	if err := applyOptsCtr(opts, createOpts...); err != nil {
 		return nil, err
 	}
-	return newContainerdClient(opts.namespace, opts.connectionPath, opts.rootExec, opts.metaPath, opts.registryConfigs, opts.imageDecKeys, opts.imageDecRecipients, opts.runcRuntime, opts.imageExpiry, opts.imageExpiryDisable)
+	return newContainerdClient(opts.namespace, opts.connectionPath, opts.rootExec, opts.metaPath, opts.registryConfigs, opts.imageDecKeys, opts.imageDecRecipients, opts.runcRuntime, opts.imageExpiry, opts.imageExpiryDisable, opts.leaseID)
 }

--- a/containerm/ctr/ctrd_spi.go
+++ b/containerm/ctr/ctrd_spi.go
@@ -106,12 +106,9 @@ type ctrdSpi struct {
 	imageService    images.Store
 }
 
-const (
-	containerManagementLeaseID = "kanto-cm.lease"
-	containerdGCExpireLabel    = "containerd.io/gc.expire"
-)
+const containerdGCExpireLabel = "containerd.io/gc.expire"
 
-func newContainerdSpi(rpcAddress string, namespace string, snapshotterType string, metaPath string) (containerdSpi, error) {
+func newContainerdSpi(rpcAddress, namespace, snapshotterType, metaPath, leaseID string) (containerdSpi, error) {
 	ctrdClient, err := containerd.New(rpcAddress, containerd.WithDefaultNamespace(namespace))
 	if err != nil {
 		return nil, err
@@ -128,10 +125,10 @@ func newContainerdSpi(rpcAddress string, namespace string, snapshotterType strin
 
 	for _, l := range leaseList {
 		log.Debug("checking lease with ID = %s", l.ID)
-		if l.ID != containerManagementLeaseID {
+		if l.ID != leaseID {
 			continue
 		}
-		log.Debug("found lease with ID = %s", containerManagementLeaseID)
+		log.Debug("found lease with ID = %s", leaseID)
 		foundExpireLabel := false
 		for k := range l.Labels {
 			if k == containerdGCExpireLabel {
@@ -139,7 +136,7 @@ func newContainerdSpi(rpcAddress string, namespace string, snapshotterType strin
 				break
 			}
 		}
-		log.Debug("is expired lease %s - %v", containerManagementLeaseID, foundExpireLabel)
+		log.Debug("is expired lease %s - %v", leaseID, foundExpireLabel)
 		// found a lease that matched the condition, just return
 		if !foundExpireLabel {
 			// remove images content from the lease
@@ -166,7 +163,7 @@ func newContainerdSpi(rpcAddress string, namespace string, snapshotterType strin
 				snapshotService: ctrdClient.SnapshotService(snapshotterType),
 			}, nil
 		}
-		log.Debug("deleting expired lease %s", containerManagementLeaseID)
+		log.Debug("deleting expired lease %s", leaseID)
 		// found a lease with id is container-management.lease and has expire time,
 		// then just delete it and wait to recreate a new lease.
 		if err := leaseSrv.Delete(context.TODO(), l); err != nil {
@@ -174,9 +171,9 @@ func newContainerdSpi(rpcAddress string, namespace string, snapshotterType strin
 		}
 
 	}
-	log.Debug("creating new lease with id = %s ", containerManagementLeaseID)
+	log.Debug("creating new lease with id = %s ", leaseID)
 	// not found a matched lease so it must be created
-	if lease, err = leaseSrv.Create(context.TODO(), leases.WithID(containerManagementLeaseID)); err != nil {
+	if lease, err = leaseSrv.Create(context.TODO(), leases.WithID(leaseID)); err != nil {
 		return nil, err
 	}
 	log.Debug("will set lease to %v with ID - %s", &lease, (&lease).ID)

--- a/containerm/ctr/ctrd_spi.go
+++ b/containerm/ctr/ctrd_spi.go
@@ -108,7 +108,7 @@ type ctrdSpi struct {
 
 const containerdGCExpireLabel = "containerd.io/gc.expire"
 
-func newContainerdSpi(rpcAddress, namespace, snapshotterType, metaPath, leaseID string) (containerdSpi, error) {
+func newContainerdSpi(rpcAddress string, namespace string, snapshotterType string, metaPath string, leaseID string) (containerdSpi, error) {
 	ctrdClient, err := containerd.New(rpcAddress, containerd.WithDefaultNamespace(namespace))
 	if err != nil {
 		return nil, err

--- a/containerm/ctr/ctrd_spi_events_test.go
+++ b/containerm/ctr/ctrd_spi_events_test.go
@@ -24,7 +24,10 @@ import (
 )
 
 func TestSubscribe(t *testing.T) {
-	const testNamespace = "test-namespace"
+	const (
+		testNamespace  = "test-namespace"
+		testSpiLeaseID = "test.lease"
+	)
 
 	testChanEnv := make(<-chan *events.Envelope)
 	testChanErr := make(<-chan error, 1)
@@ -35,10 +38,11 @@ func TestSubscribe(t *testing.T) {
 	defer mockCtrl.Finish()
 	mockCtrdWrapper := ctrdMocks.NewMockcontainerClientWrapper(mockCtrl)
 	ctx := context.Background()
-	testSpi := &ctrdSpi{client: mockCtrdWrapper, lease: &leases.Lease{ID: containerManagementLeaseID}, namespace: testNamespace}
+
+	testSpi := &ctrdSpi{client: mockCtrdWrapper, lease: &leases.Lease{ID: testSpiLeaseID}, namespace: testNamespace}
 
 	expectedContext := namespaces.WithNamespace(ctx, testNamespace)
-	expectedContext = leases.WithLease(expectedContext, containerManagementLeaseID)
+	expectedContext = leases.WithLease(expectedContext, testSpiLeaseID)
 	mockCtrdWrapper.EXPECT().Subscribe(expectedContext, testFilters).Times(1).Return(testChanEnv, testChanErr)
 
 	// test

--- a/containerm/daemon/daemon_command.go
+++ b/containerm/daemon/daemon_command.go
@@ -47,6 +47,7 @@ func setupCommandFlags(cmd *cobra.Command) {
 	flagSet.StringVar(&cfg.ContainerClientConfig.CtrRuncRuntime, "ccl-runc-runtime", cfg.ContainerClientConfig.CtrRuncRuntime, "Specify a default global runc runtime - possible values are io.containerd.runtime.v1.linux, io.containerd.runc.v1 and io.containerd.runc.v2. ")
 	flagSet.DurationVar(&cfg.ContainerClientConfig.CtrImageExpiry, "ccl-image-expiry", cfg.ContainerClientConfig.CtrImageExpiry, "Specify the time period for the cached images and content to be kept in the form of e.g. 72h3m0.5s")
 	flagSet.BoolVar(&cfg.ContainerClientConfig.CtrImageExpiryDisable, "ccl-image-expiry-disable", cfg.ContainerClientConfig.CtrImageExpiryDisable, "Disables expiry management of cached images and content - must be used with caution as it may lead to large memory volumes being persistently allocated")
+	flagSet.StringVar(&cfg.ContainerClientConfig.CtrLeaseID, "ccl-lease-id", cfg.ContainerClientConfig.CtrLeaseID, "Specify the lease identifier to be used for container resources persistence")
 
 	// init network manager flags
 	flagSet.StringVar(&cfg.NetworkConfig.NetType, "net-type", cfg.NetworkConfig.NetType, "Specify the default network management type for containers")

--- a/containerm/daemon/daemon_config.go
+++ b/containerm/daemon/daemon_config.go
@@ -54,6 +54,7 @@ type containerRuntimeConfig struct {
 	CtrRuncRuntime        string                     `json:"runc_runtime,omitempty"`
 	CtrImageExpiry        time.Duration              `json:"image_expiry,omitempty"`
 	CtrImageExpiryDisable bool                       `json:"image_expiry_disable,omitempty"`
+	CtrLeaseID            string                     `json:"lease_id,omitempty"`
 }
 
 func (cfg *containerRuntimeConfig) UnmarshalJSON(data []byte) error {

--- a/containerm/daemon/daemon_config_default.go
+++ b/containerm/daemon/daemon_config_default.go
@@ -47,6 +47,7 @@ const (
 	containerClientRuncRuntimeDefault = string(types.RuntimeTypeV2runcV2)
 	containerClientImageExpiry        = 31 * 24 * time.Hour // 31 days
 	containerClientImageExpiryDisable = false
+	containerClientLeaseIDDefault     = "kanto-cm.lease"
 
 	// default network manager config
 	networkManagerNetTypeDefault  = string(types.NetworkModeBridge)
@@ -119,6 +120,7 @@ func getDefaultInstance() *config {
 			CtrRuncRuntime:        containerClientRuncRuntimeDefault,
 			CtrImageExpiry:        containerClientImageExpiry,
 			CtrImageExpiryDisable: containerClientImageExpiryDisable,
+			CtrLeaseID:            containerClientLeaseIDDefault,
 		},
 		NetworkConfig: &networkConfig{
 			NetType:     networkManagerNetTypeDefault,

--- a/containerm/daemon/daemon_config_util.go
+++ b/containerm/daemon/daemon_config_util.go
@@ -42,6 +42,7 @@ func extractCtrClientConfigOptions(daemonConfig *config) []ctr.ContainerOpts {
 		ctr.WithCtrdRuncRuntime(daemonConfig.ContainerClientConfig.CtrRuncRuntime),
 		ctr.WithCtrdImageExpiry(daemonConfig.ContainerClientConfig.CtrImageExpiry),
 		ctr.WithCtrdImageExpiryDisable(daemonConfig.ContainerClientConfig.CtrImageExpiryDisable),
+		ctr.WithCtrdLeaseID(daemonConfig.ContainerClientConfig.CtrLeaseID),
 	)
 	return ctrOpts
 }
@@ -217,6 +218,7 @@ func dumpContClient(configInstance *config) {
 		}
 		log.Debug("[daemon_cfg][ccl-image-expiry] : %s", configInstance.ContainerClientConfig.CtrImageExpiry)
 		log.Debug("[daemon_cfg][ccl-image-expiry-disable] : %v", configInstance.ContainerClientConfig.CtrImageExpiryDisable)
+		log.Debug("[daemon_cfg][ccl-lease-id] : %s", configInstance.ContainerClientConfig.CtrLeaseID)
 	}
 }
 

--- a/containerm/daemon/daemon_test.go
+++ b/containerm/daemon/daemon_test.go
@@ -250,6 +250,10 @@ func TestSetCommandFlags(t *testing.T) {
 			flag:         "ccl-image-expiry-disable",
 			expectedType: reflect.Bool.String(),
 		},
+		"test_flags_ccl-lease-id": {
+			flag:         "ccl-lease-id",
+			expectedType: reflect.String.String(),
+		},
 		"test_flags_net-type": {
 			flag:         "net-type",
 			expectedType: reflect.String.String(),

--- a/containerm/pkg/testutil/config/daemon-config.json
+++ b/containerm/pkg/testutil/config/daemon-config.json
@@ -24,7 +24,8 @@
     "home_dir": "/var/lib/container-management",
     "runc_runtime": "io.containerd.runc.v2",
     "image_expiry": "744h",
-    "image_expiry_disable": false
+    "image_expiry_disable": false,
+    "lease_id": "kanto-cm.lease"
   },
   "network": {
     "type": "bridge",


### PR DESCRIPTION
[#38] Make the container management lease ID configurable

- add daemon flag --ccl-lease-id
- add unit tests

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov3@bosch.io>