### PR TITLE
Add support for TCP protocol when using --host flag

### DIFF
--- a/containerm/cli/cli.go
+++ b/containerm/cli/cli.go
@@ -86,7 +86,7 @@ func (c *cli) initLog() {
 }
 
 func (c *cli) initGwManClient() {
-	gwClient, err := client.New(c.config.addressPath)
+	gwClient, err := client.New(c.config.addressPath, time.Duration(c.config.timeout)*time.Second)
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/containerm/cli/cli_config.go
+++ b/containerm/cli/cli_config.go
@@ -14,11 +14,13 @@ package main
 
 const (
 	cmdAddressPathDefault = "/run/container-management/container-management.sock"
+	cmdTimeoutDefault     = 30
 	cmdDebugDefault       = false
 )
 
 type config struct {
 	addressPath string
+	timeout     int
 	debug       bool
 }
 
@@ -27,6 +29,9 @@ func (c *cli) setupCommandFlags() {
 
 	// init connection address to the GW CM daemon flag
 	flagSet.StringVar(&c.config.addressPath, "host", cmdAddressPathDefault, "Specify the address path to the Eclipse Kanto container management")
+
+	// init connection timeout
+	flagSet.IntVar(&c.config.timeout, "timeout", cmdTimeoutDefault, "Specify the connection timeout in seconds to the Eclipse Kanto container management")
 
 	// init debug flags
 	flagSet.BoolVar(&c.config.debug, "debug", cmdDebugDefault, "Switch commands log level to DEBUG mode")

--- a/containerm/cli/cli_test.go
+++ b/containerm/cli/cli_test.go
@@ -19,8 +19,9 @@ import (
 
 const (
 	// command flags
-	cmdFlagHost  = "host"
-	cmdFlagDebug = "debug"
+	cmdFlagHost    = "host"
+	cmdFlagDebug   = "debug"
+	cmdFlagTimeout = "timeout"
 
 	// test input constants
 	testAddressPath = "test-address-path"
@@ -44,12 +45,14 @@ func TestCmdFlags(t *testing.T) {
 
 	expectedCfg := config{
 		addressPath: testAddressPath,
+		timeout:     30,
 		debug:       true,
 	}
 
 	flagsToApply := map[string]string{
-		cmdFlagHost:  expectedCfg.addressPath,
-		cmdFlagDebug: fmt.Sprintf("%v", expectedCfg.debug),
+		cmdFlagHost:    expectedCfg.addressPath,
+		cmdFlagTimeout: fmt.Sprintf("%d", expectedCfg.timeout),
+		cmdFlagDebug:   fmt.Sprintf("%v", expectedCfg.debug),
 	}
 
 	execTestSetupFlags(t, ct, flagsToApply, expectedCfg)
@@ -71,6 +74,7 @@ func (c *cliCmdTest) commandConfig() interface{} {
 func (c *cliCmdTest) commandConfigDefault() interface{} {
 	return config{
 		addressPath: cmdAddressPathDefault,
+		timeout:     cmdTimeoutDefault,
 		debug:       cmdDebugDefault,
 	}
 }

--- a/containerm/cli/cli_test.go
+++ b/containerm/cli/cli_test.go
@@ -22,9 +22,6 @@ const (
 	cmdFlagHost    = "host"
 	cmdFlagDebug   = "debug"
 	cmdFlagTimeout = "timeout"
-
-	// test input constants
-	testAddressPath = "test-address-path"
 )
 
 type cliCmdTest struct {
@@ -44,8 +41,8 @@ func TestCmdFlags(t *testing.T) {
 	ct.init()
 
 	expectedCfg := config{
-		addressPath: testAddressPath,
-		timeout:     30,
+		addressPath: "test-addr",
+		timeout:     42,
 		debug:       true,
 	}
 

--- a/containerm/client/client_init.go
+++ b/containerm/client/client_init.go
@@ -29,7 +29,7 @@ func New(connectionAddress string) (Client, error) {
 	// Set up a connection to the server.
 	gopts := []grpc.DialOption{
 		grpc.WithInsecure(),
-		grpc.WithDialer(getDialer),
+		grpc.WithContextDialer(getDialer),
 		grpc.WithBlock(),
 	}
 
@@ -54,7 +54,7 @@ func newContainersClient(conn *grpc.ClientConn) (Client, error) {
 	}, nil
 }
 
-func getDialer(addr string, duration time.Duration) (net.Conn, error) {
+func getDialer(ctx context.Context, addr string) (net.Conn, error) {
 	url, err := url.Parse(addr)
 	if err != nil {
 		return nil, err

--- a/containerm/client/client_init.go
+++ b/containerm/client/client_init.go
@@ -25,7 +25,7 @@ import (
 )
 
 // New creates a new containers client.
-func New(connectionAddress string) (Client, error) {
+func New(connectionAddress string, timeout time.Duration) (Client, error) {
 	// Set up a connection to the server.
 	gopts := []grpc.DialOption{
 		grpc.WithInsecure(),
@@ -34,7 +34,7 @@ func New(connectionAddress string) (Client, error) {
 	}
 
 	parentCtx := context.Background()
-	ctx, cancel := context.WithTimeout(parentCtx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(parentCtx, timeout)
 	defer cancel()
 
 	conn, err := grpc.DialContext(ctx, connectionAddress, gopts...)

--- a/containerm/client/client_init.go
+++ b/containerm/client/client_init.go
@@ -62,8 +62,10 @@ func getDialer(ctx context.Context, addr string) (net.Conn, error) {
 	switch url.Scheme {
 	case "tcp", "tcp4", "tcp6":
 		return tcpConnect(url.Scheme, url.Host)
-	default:
+	case "unix", "":
 		return unixConnect(addr)
+	default:
+		return nil, fmt.Errorf("unsupported scheme %s", url.Scheme)
 	}
 }
 


### PR DESCRIPTION
[#84] TCP Protocol is not supported by kanto-cm when using the --host flag

- the behaviour to default to `unix` is still preserved
- the deprecated `grpc.Dial` method is replaced with `grpc.DialContext`
- `WithBlock()` option is added so we can benefit from the context timeout

Signed-off-by: Kristiyan Gostev <kristiyan.gostev@bosch.io>