### PR TITLE
Expose flags --host and --debug to all child commands

### DIFF
--- a/containerm/cli/cli_config.go
+++ b/containerm/cli/cli_config.go
@@ -23,7 +23,7 @@ type config struct {
 }
 
 func (c *cli) setupCommandFlags() {
-	flagSet := c.rootCmd.Flags()
+	flagSet := c.rootCmd.PersistentFlags()
 
 	// init connection address to the GW CM daemon flag
 	flagSet.StringVar(&c.config.addressPath, "host", cmdAddressPathDefault, "Specify the address path to the Eclipse Kanto container management")

--- a/containerm/cli/cli_test.go
+++ b/containerm/cli/cli_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+const (
+	// command flags
+	cmdFlagHost  = "host"
+	cmdFlagDebug = "debug"
+
+	// test input constants
+	testAddressPath = "test-address-path"
+)
+
+type cliCmdTest struct {
+	cliCommandTestBase
+	cli *cli
+}
+
+func TestCmdInit(t *testing.T) {
+	ct := &cliCmdTest{}
+	ct.init()
+
+	execTestInit(t, ct)
+}
+
+func TestCmdFlags(t *testing.T) {
+	ct := &cliCmdTest{}
+	ct.init()
+
+	expectedCfg := config{
+		addressPath: testAddressPath,
+		debug:       true,
+	}
+
+	flagsToApply := map[string]string{
+		cmdFlagHost:  expectedCfg.addressPath,
+		cmdFlagDebug: fmt.Sprintf("%v", expectedCfg.debug),
+	}
+
+	execTestSetupFlags(t, ct, flagsToApply, expectedCfg)
+}
+
+func (c *cliCmdTest) prepareCommand(flagsCfg map[string]string) error {
+	cli := newCli()
+	c.cli, c.baseCmd = cli, &baseCommand{cmd: cli.rootCmd, cli: cli}
+
+	cli.setupCommandFlags()
+
+	return setCmdFlags(flagsCfg, c.cli.rootCmd)
+}
+
+func (c *cliCmdTest) commandConfig() interface{} {
+	return c.cli.config
+}
+
+func (c *cliCmdTest) commandConfigDefault() interface{} {
+	return config{
+		addressPath: cmdAddressPathDefault,
+		debug:       cmdDebugDefault,
+	}
+}


### PR DESCRIPTION
[#83] Flags --host and --debug should be global

- Flags `--host` and `--debug` are now inherited by all child commands of `kanto-cm`
- The flags can be seen when you list the help commands under `Global Flags`.

Signed-off-by: Kristiyan Gostev [kristiyan.gostev@bosch.io](mailto:kristiyan.gostev@bosch.io)