### PR TITLE
Directory handling improvements on daemon start

### DIFF
--- a/containerm/daemon/daemon_start.go
+++ b/containerm/daemon/daemon_start.go
@@ -73,7 +73,8 @@ func runDaemon(cmd *cobra.Command) error {
 	}
 
 	gwDaemon.init()
-	l, lockErr := newRunLock(path.Join(gwDaemon.config.ManagerConfig.MgrExecPath, lockFileName))
+	lockFilePath := path.Join(gwDaemon.config.ManagerConfig.MgrExecPath, lockFileName)
+	l, lockErr := newRunLock(lockFilePath)
 	if lockErr == nil {
 		err = l.TryLock()
 		if err == nil {
@@ -100,7 +101,7 @@ func runDaemon(cmd *cobra.Command) error {
 			return err
 		}
 	} else {
-		log.ErrorErr(lockErr, "unable to create lock file at %s", gwDaemon.config.ManagerConfig.MgrExecPath)
+		log.ErrorErr(lockErr, "unable to create lock file %s", lockFilePath)
 		return lockErr
 	}
 	return nil

--- a/containerm/daemon/daemon_start.go
+++ b/containerm/daemon/daemon_start.go
@@ -73,15 +73,12 @@ func runDaemon(cmd *cobra.Command) error {
 	}
 
 	gwDaemon.init()
-	sockDir, _ := path.Split(gwDaemon.config.GrpcServerConfig.GrpcServerAddressPath)
-	runLockFile := path.Join(sockDir, string(os.PathSeparator), lockFileName)
-	l, lockErr := newRunLock(runLockFile)
+	l, lockErr := newRunLock(path.Join(gwDaemon.config.ManagerConfig.MgrExecPath, lockFileName))
 	if lockErr == nil {
 		err = l.TryLock()
 		if err == nil {
 			defer l.Unlock()
 
-			os.MkdirAll(sockDir, 0755)
 			os.Remove(gwDaemon.config.GrpcServerConfig.GrpcServerAddressPath)
 
 			err := gwDaemon.start()
@@ -103,7 +100,7 @@ func runDaemon(cmd *cobra.Command) error {
 			return err
 		}
 	} else {
-		log.ErrorErr(lockErr, "unable to create lock file at %s", runLockFile)
+		log.ErrorErr(lockErr, "unable to create lock file at %s", gwDaemon.config.ManagerConfig.MgrExecPath)
 		return lockErr
 	}
 	return nil

--- a/containerm/mgr/mgr_internal_init.go
+++ b/containerm/mgr/mgr_internal_init.go
@@ -24,6 +24,14 @@ import (
 )
 
 func newContainerMgr(metaPath string, execPath string, defaultCtrsStopTimeout int64, ctrClient ctr.ContainerAPIClient, netMgr network.ContainerNetworkManager, eventsMgr events.ContainerEventsManager) (ContainerManager, error) {
+	if err := util.MkDir(execPath); err != nil {
+		return nil, err
+	}
+
+	if err := util.MkDir(metaPath); err != nil {
+		return nil, err
+	}
+
 	locksCache := util.NewLocksCache()
 	ctrRepository := containerFsRepository{metaPath: metaPath, locksCache: &locksCache}
 

--- a/containerm/network/libnet_mgr_init.go
+++ b/containerm/network/libnet_mgr_init.go
@@ -14,9 +14,18 @@ package network
 
 import (
 	"github.com/eclipse-kanto/container-management/containerm/registry"
+	"github.com/eclipse-kanto/container-management/containerm/util"
 )
 
 func newLibnetworkMgr(netConfig config) (ContainerNetworkManager, error) {
+	if err := util.MkDirs(netConfig.execRoot); err != nil {
+		return nil, err
+	}
+
+	if err := util.MkDir(netConfig.metaPath); err != nil {
+		return nil, err
+	}
+
 	return &libnetworkMgr{&netConfig, nil}, nil
 }
 

--- a/containerm/network/libnet_mgr_init_test.go
+++ b/containerm/network/libnet_mgr_init_test.go
@@ -13,6 +13,7 @@
 package network
 
 import (
+	"os"
 	"testing"
 
 	"github.com/eclipse-kanto/container-management/containerm/pkg/testutil"
@@ -20,12 +21,18 @@ import (
 )
 
 func TestInit(t *testing.T) {
+	testDir := "test"
+	defer os.Remove(testDir)
+
 	nOpts := []NetOpt{
 		WithLibNetType(bridgeNetworkName),
 		WithLibNetIPTables(true),
 		WithLibNetMtu(1500),
 		WithLibNetIPForward(true),
-		WithLibNetName("test0")}
+		WithLibNetName("test0"),
+		WithLibNetExecRoot(testDir),
+		WithLibNetMetaPath(testDir),
+	}
 	registryCtx := &registry.ServiceRegistryContext{
 		Config: nOpts,
 	}

--- a/containerm/network/libnet_mgr_init_test.go
+++ b/containerm/network/libnet_mgr_init_test.go
@@ -18,13 +18,13 @@ import (
 
 	"github.com/eclipse-kanto/container-management/containerm/pkg/testutil"
 	"github.com/eclipse-kanto/container-management/containerm/registry"
+	"github.com/eclipse-kanto/container-management/containerm/util"
 )
 
 func TestInit(t *testing.T) {
 	execRootDir := "testdata/execRoot"
 	metaPathDir := "testdata/metaPath"
-	defer os.Remove(execRootDir)
-	defer os.Remove(metaPathDir)
+	defer os.RemoveAll("testdata")
 
 	nOpts := []NetOpt{
 		WithLibNetType(bridgeNetworkName),
@@ -44,13 +44,13 @@ func TestInit(t *testing.T) {
 	testNetMgr := netMgr.(*libnetworkMgr)
 	testutil.AssertNotNil(t, testNetMgr)
 
-	info, err := os.Stat(execRootDir)
+	isDirectory, err := util.IsDirectory(execRootDir)
 	testutil.AssertNil(t, err)
-	testutil.AssertNotNil(t, info)
+	testutil.AssertTrue(t, isDirectory)
 
-	info, err = os.Stat(metaPathDir)
+	isDirectory, err = util.IsDirectory(metaPathDir)
 	testutil.AssertNil(t, err)
-	testutil.AssertNotNil(t, info)
+	testutil.AssertTrue(t, isDirectory)
 
 	expectedNetOpts := &netOpts{}
 	applyOptsNet(expectedNetOpts, nOpts...)

--- a/containerm/network/libnet_mgr_init_test.go
+++ b/containerm/network/libnet_mgr_init_test.go
@@ -21,8 +21,10 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	testDir := "test"
-	defer os.Remove(testDir)
+	execRootDir := "testdata/execRoot"
+	metaPathDir := "testdata/metaPath"
+	defer os.Remove(execRootDir)
+	defer os.Remove(metaPathDir)
 
 	nOpts := []NetOpt{
 		WithLibNetType(bridgeNetworkName),
@@ -30,9 +32,10 @@ func TestInit(t *testing.T) {
 		WithLibNetMtu(1500),
 		WithLibNetIPForward(true),
 		WithLibNetName("test0"),
-		WithLibNetExecRoot(testDir),
-		WithLibNetMetaPath(testDir),
+		WithLibNetExecRoot(execRootDir),
+		WithLibNetMetaPath(metaPathDir),
 	}
+
 	registryCtx := &registry.ServiceRegistryContext{
 		Config: nOpts,
 	}
@@ -40,6 +43,14 @@ func TestInit(t *testing.T) {
 	testutil.AssertError(t, nil, err)
 	testNetMgr := netMgr.(*libnetworkMgr)
 	testutil.AssertNotNil(t, testNetMgr)
+
+	info, err := os.Stat(execRootDir)
+	testutil.AssertNil(t, err)
+	testutil.AssertNotNil(t, info)
+
+	info, err = os.Stat(metaPathDir)
+	testutil.AssertNil(t, err)
+	testutil.AssertNotNil(t, info)
 
 	expectedNetOpts := &netOpts{}
 	applyOptsNet(expectedNetOpts, nOpts...)

--- a/containerm/server/grpc_server_internal_init.go
+++ b/containerm/server/grpc_server_internal_init.go
@@ -67,5 +67,4 @@ func registryInit(registryCtx *registry.ServiceRegistryContext) (interface{}, er
 	}
 
 	return newGrpcServer(grpcServerOpts.network, grpcServerOpts.addressPath, grpcServices)
-
 }

--- a/containerm/server/grpc_server_internal_init.go
+++ b/containerm/server/grpc_server_internal_init.go
@@ -13,13 +13,23 @@
 package server
 
 import (
+	"path"
+
 	"github.com/eclipse-kanto/container-management/containerm/log"
 	"github.com/eclipse-kanto/container-management/containerm/registry"
+	"github.com/eclipse-kanto/container-management/containerm/util"
 	"google.golang.org/grpc"
 )
 
 func newGrpcServer(network string, addressPath string, grpcServices []registry.GrpcService) (registry.GrpcServer, error) {
 	server := grpc.NewServer()
+
+	if network == "unix" {
+		addressDir, _ := path.Split(addressPath)
+		if err := util.MkDir(addressDir); err != nil {
+			return nil, err
+		}
+	}
 
 	for _, grpcService := range grpcServices {
 		grpcService.Register(server)

--- a/containerm/server/grpc_server_internal_init_test.go
+++ b/containerm/server/grpc_server_internal_init_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/eclipse-kanto/container-management/containerm/pkg/testutil"
 	mockGrpc "github.com/eclipse-kanto/container-management/containerm/pkg/testutil/mocks/registry"
 	"github.com/eclipse-kanto/container-management/containerm/registry"
+	"github.com/eclipse-kanto/container-management/containerm/util"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 )
@@ -55,7 +56,7 @@ func TestRegistryInit(t *testing.T) {
 	errServiceSet.Add(sInfoErr)
 	serviceSet.Add(sInfo)
 	emptyServiceSet := registry.NewServiceInfoSet()
-	grpcServiceMock.EXPECT().Register(gomock.Any()).Times(1).Return(nil)
+	grpcServiceMock.EXPECT().Register(gomock.Any()).Times(2).Return(nil)
 
 	testCases := map[string]struct {
 		arg            *registry.ServiceRegistryContext
@@ -72,6 +73,17 @@ func TestRegistryInit(t *testing.T) {
 			),
 			wantNewtork:    "bridge",
 			wantAdressPath: "/run/test.sock",
+			expectedErr:    nil,
+		},
+		"register_without_err_unix": {
+			arg: registry.NewContext(
+				context.Background(),
+				[]GrpcServerOpt{WithGrpcServerNetwork("unix"), WithGrpcServerAddressPath("testdata/run/test.sock")},
+				testRegValid,
+				serviceSet,
+			),
+			wantNewtork:    "unix",
+			wantAdressPath: "testdata/run/test.sock",
 			expectedErr:    nil,
 		},
 		"register_with_err_empty_service_set": {
@@ -109,10 +121,10 @@ func TestRegistryInit(t *testing.T) {
 				testutil.AssertEqual(t, testCase.wantAdressPath, grpcSrv.addressPath)
 				if grpcSrv.network == "unix" {
 					addressDir, _ := path.Split(grpcSrv.addressPath)
-					info, err := os.Stat(addressDir)
+					defer os.RemoveAll(addressDir)
+					isDirectory, err := util.IsDirectory(addressDir)
 					testutil.AssertNil(t, err)
-					testutil.AssertNotNil(t, info)
-					testutil.AssertNil(t, os.Remove(addressDir))
+					testutil.AssertTrue(t, isDirectory)
 				}
 			}
 		})

--- a/containerm/server/grpc_server_internal_init_test.go
+++ b/containerm/server/grpc_server_internal_init_test.go
@@ -14,6 +14,8 @@ package server
 
 import (
 	"context"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/containerd/containerd/errdefs"
@@ -105,8 +107,14 @@ func TestRegistryInit(t *testing.T) {
 				testutil.AssertNotNil(t, grpcSrv)
 				testutil.AssertEqual(t, testCase.wantNewtork, grpcSrv.network)
 				testutil.AssertEqual(t, testCase.wantAdressPath, grpcSrv.addressPath)
+				if grpcSrv.network == "unix" {
+					addressDir, _ := path.Split(grpcSrv.addressPath)
+					info, err := os.Stat(addressDir)
+					testutil.AssertNil(t, err)
+					testutil.AssertNotNil(t, info)
+					testutil.AssertNil(t, os.Remove(addressDir))
+				}
 			}
-
 		})
 	}
 

--- a/containerm/things/features_rollouts_software_updatable_internal_test.go
+++ b/containerm/things/features_rollouts_software_updatable_internal_test.go
@@ -15,6 +15,7 @@ package things
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -59,6 +60,7 @@ var (
 )
 
 func TestCreateSUPFeature(t *testing.T) {
+	defer os.RemoveAll(testThingsStoragePath)
 	setupSUFeature(t)
 	testSUFeature = testSoftwareUpdatable.(*softwareUpdatable).createFeature()
 	testutil.AssertEqual(t, SoftwareUpdatableFeatureID, testSUFeature.GetID())
@@ -82,6 +84,7 @@ var (
 )
 
 func TestSUFeatureOperationsHandler(t *testing.T) {
+	defer os.RemoveAll(testThingsStoragePath)
 	tests := map[string]struct {
 		operation     string
 		opts          interface{}
@@ -255,6 +258,7 @@ func TestSUFeatureOperationsHandler(t *testing.T) {
 	// execute tests
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
+			defer os.RemoveAll(testThingsStoragePath)
 			t.Log(testName)
 
 			expectedRunErr := testCase.mockExecution(t)

--- a/containerm/things/features_rollouts_software_updatable_internal_test.go
+++ b/containerm/things/features_rollouts_software_updatable_internal_test.go
@@ -456,7 +456,7 @@ func mockExecInstallErrorWhileStartingContainer(t *testing.T) error {
 	return nil
 }
 
-//  Simulate - 1 of each in order: success, error, success after error
+// Simulate - 1 of each in order: success, error, success after error
 func mockExecSURemoveForced(t *testing.T) error {
 	setupSUFeature(t)
 	gomock.InOrder(
@@ -503,16 +503,19 @@ func setupSUFeature(t *testing.T) {
 	setupEventsManagerMock(controller)
 	setupThingMock(controller)
 	setupDummyHTTPServer(true)
-	setupThingsContainerManager(controller)
+	testutil.AssertNil(t, setupThingsContainerManager(controller))
 	testSoftwareUpdatable = newSoftwareUpdatable(mockThing, mockContainerManager, mockEventsManager)
 }
 
 // HTTP Server mock -----------------------------------------------
 
-/* Basically the expected outgoing http request could be asserted by either
+/*
+	Basically the expected outgoing http request could be asserted by either
+
 creating a wrapper http client and mocking it OR by mocking an http server.
 The second approach looks cleaner at the moment,
-as it does not require changes in the source code. */
+as it does not require changes in the source code.
+*/
 func setupDummyHTTPServer(plain bool) {
 	handler := http.NewServeMux()
 	handler.HandleFunc(testHTTPServerImageURLPathValid, validURLHandler)

--- a/containerm/things/things_containers_service_init.go
+++ b/containerm/things/things_containers_service_init.go
@@ -18,6 +18,7 @@ import (
 	"github.com/eclipse-kanto/container-management/containerm/events"
 	"github.com/eclipse-kanto/container-management/containerm/mgr"
 	"github.com/eclipse-kanto/container-management/containerm/registry"
+	"github.com/eclipse-kanto/container-management/containerm/util"
 	"github.com/eclipse-kanto/container-management/things/client"
 )
 
@@ -37,7 +38,10 @@ func newThingsContainerManager(mgr mgr.ContainerManager, eventsMgr events.Contai
 	acknowledgeTimeout time.Duration,
 	subscribeTimeout time.Duration,
 	unsubscribeTimeout time.Duration,
-	tlsConfig *tlsConfig) *containerThingsMgr {
+	tlsConfig *tlsConfig) (*containerThingsMgr, error) {
+	if err := util.MkDir(storagePath); err != nil {
+		return nil, err
+	}
 	thingsMgr := &containerThingsMgr{
 		storageRoot:       storagePath,
 		mgr:               mgr,
@@ -61,7 +65,7 @@ func newThingsContainerManager(mgr mgr.ContainerManager, eventsMgr events.Contai
 		WithTLSConfig(tlsConfig.RootCA, tlsConfig.ClientCert, tlsConfig.ClientKey)
 
 	thingsMgr.thingsClient = client.NewClient(thingsClientOpts)
-	return thingsMgr
+	return thingsMgr, nil
 
 }
 
@@ -96,5 +100,5 @@ func registryInit(registryCtx *registry.ServiceRegistryContext) (interface{}, er
 		tOpts.subscribeTimeout,
 		tOpts.unsubscribeTimeout,
 		tOpts.tlsConfig,
-	), nil
+	)
 }

--- a/containerm/things/things_containers_service_internal_test.go
+++ b/containerm/things/things_containers_service_internal_test.go
@@ -13,6 +13,7 @@
 package things
 
 import (
+	"os"
 	"testing"
 
 	"github.com/eclipse-kanto/container-management/containerm/pkg/testutil"
@@ -48,6 +49,7 @@ func TestProcessContainerThingDefault(t *testing.T) {
 			t.Log(testName)
 			controller := gomock.NewController(t)
 			defer controller.Finish()
+			defer os.RemoveAll(testThingsStoragePath)
 			setupManagerMock(controller)
 			setupEventsManagerMock(controller)
 			setupThingMock(controller)

--- a/containerm/things/things_containers_service_internal_test.go
+++ b/containerm/things/things_containers_service_internal_test.go
@@ -51,7 +51,7 @@ func TestProcessContainerThingDefault(t *testing.T) {
 			setupManagerMock(controller)
 			setupEventsManagerMock(controller)
 			setupThingMock(controller)
-			setupThingsContainerManager(controller)
+			testutil.AssertNil(t, setupThingsContainerManager(controller))
 
 			namespaceID := client.NewNamespacedID("things.containers.service", "test")
 			testThingsMgr.containerThingID = namespaceID.String()

--- a/containerm/things/things_containers_service_test.go
+++ b/containerm/things/things_containers_service_test.go
@@ -37,7 +37,7 @@ func TestThingsContainerServiceConnectWithCredentials(t *testing.T) {
 	setupManagerMock(controller)
 	setupEventsManagerMock(controller)
 	setupThingsContainerManager(controller)
-	testThingsMgr = newThingsContainerManager(mockContainerManager, mockEventsManager,
+	testThingsMgr, err := newThingsContainerManager(mockContainerManager, mockEventsManager,
 		testMQTTBrokerURL,
 		0,
 		0,
@@ -51,6 +51,10 @@ func TestThingsContainerServiceConnectWithCredentials(t *testing.T) {
 		0,
 		&tlsConfig{},
 	)
+	if err != nil {
+		t.Errorf("unable to create things container manager: %s", err)
+	}
+
 	setupThingMock(controller)
 
 	listener, err := net.Listen("tcp4", testMQTTBrokerURL)
@@ -84,7 +88,7 @@ func TestThingsContainerServiceConnectNoCredentials(t *testing.T) {
 	setupManagerMock(controller)
 	setupEventsManagerMock(controller)
 	setupThingsContainerManager(controller)
-	testThingsMgr = newThingsContainerManager(mockContainerManager, mockEventsManager,
+	testThingsMgr, err := newThingsContainerManager(mockContainerManager, mockEventsManager,
 		testMQTTBrokerURL,
 		0,
 		0,
@@ -98,6 +102,10 @@ func TestThingsContainerServiceConnectNoCredentials(t *testing.T) {
 		0,
 		&tlsConfig{},
 	)
+	if err != nil {
+		t.Errorf("unable to create things container manager: %s", err)
+	}
+
 	setupThingMock(controller)
 
 	listener, err := net.Listen("tcp4", testMQTTBrokerURL)

--- a/containerm/things/things_containers_service_test.go
+++ b/containerm/things/things_containers_service_test.go
@@ -14,6 +14,7 @@ package things
 
 import (
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -34,9 +35,11 @@ func TestThingsContainerServiceConnectWithCredentials(t *testing.T) {
 	defer func() {
 		controller.Finish()
 	}()
+	defer os.RemoveAll(testThingsStoragePath)
 	setupManagerMock(controller)
 	setupEventsManagerMock(controller)
-	setupThingsContainerManager(controller)
+	testutil.AssertNil(t, setupThingsContainerManager(controller))
+
 	testThingsMgr, err := newThingsContainerManager(mockContainerManager, mockEventsManager,
 		testMQTTBrokerURL,
 		0,
@@ -51,9 +54,7 @@ func TestThingsContainerServiceConnectWithCredentials(t *testing.T) {
 		0,
 		&tlsConfig{},
 	)
-	if err != nil {
-		t.Errorf("unable to create things container manager: %s", err)
-	}
+	testutil.AssertNil(t, err)
 
 	setupThingMock(controller)
 
@@ -85,9 +86,11 @@ func TestThingsContainerServiceConnectNoCredentials(t *testing.T) {
 	defer func() {
 		controller.Finish()
 	}()
+	defer os.RemoveAll(testThingsStoragePath)
 	setupManagerMock(controller)
 	setupEventsManagerMock(controller)
-	setupThingsContainerManager(controller)
+	testutil.AssertNil(t, setupThingsContainerManager(controller))
+
 	testThingsMgr, err := newThingsContainerManager(mockContainerManager, mockEventsManager,
 		testMQTTBrokerURL,
 		0,
@@ -102,9 +105,7 @@ func TestThingsContainerServiceConnectNoCredentials(t *testing.T) {
 		0,
 		&tlsConfig{},
 	)
-	if err != nil {
-		t.Errorf("unable to create things container manager: %s", err)
-	}
+	testutil.AssertNil(t, err)
 
 	setupThingMock(controller)
 

--- a/containerm/things/things_test_base_test.go
+++ b/containerm/things/things_test_base_test.go
@@ -73,7 +73,7 @@ const (
 )
 
 func setupThingsContainerManager(controller *gomock.Controller) {
-	testThingsMgr = newThingsContainerManager(mockContainerManager, mockEventsManager,
+	testThingsMgr, _ = newThingsContainerManager(mockContainerManager, mockEventsManager,
 		"",
 		0,
 		0,

--- a/containerm/things/things_test_base_test.go
+++ b/containerm/things/things_test_base_test.go
@@ -13,8 +13,6 @@
 package things
 
 import (
-	"os"
-
 	"github.com/golang/mock/gomock"
 
 	"github.com/eclipse-kanto/container-management/containerm/containers/types"
@@ -75,7 +73,6 @@ const (
 )
 
 func setupThingsContainerManager(controller *gomock.Controller) error {
-	defer os.RemoveAll(testThingsStoragePath)
 	mgr, err := newThingsContainerManager(mockContainerManager, mockEventsManager,
 		"",
 		0,

--- a/containerm/things/things_test_base_test.go
+++ b/containerm/things/things_test_base_test.go
@@ -13,6 +13,8 @@
 package things
 
 import (
+	"os"
+
 	"github.com/golang/mock/gomock"
 
 	"github.com/eclipse-kanto/container-management/containerm/containers/types"
@@ -72,8 +74,9 @@ const (
 	testThingsStoragePath = "../pkg/testutil/metapath/valid/things"
 )
 
-func setupThingsContainerManager(controller *gomock.Controller) {
-	testThingsMgr, _ = newThingsContainerManager(mockContainerManager, mockEventsManager,
+func setupThingsContainerManager(controller *gomock.Controller) error {
+	defer os.RemoveAll(testThingsStoragePath)
+	mgr, err := newThingsContainerManager(mockContainerManager, mockEventsManager,
 		"",
 		0,
 		0,
@@ -85,5 +88,8 @@ func setupThingsContainerManager(controller *gomock.Controller) {
 		0,
 		0,
 		0,
-		&tlsConfig{})
+		&tlsConfig{},
+	)
+	testThingsMgr = mgr
+	return err
 }


### PR DESCRIPTION
[#100] Unable to create lock file at /run/container-management/lock Error: no such file or directory
- Ensure that all necessary directories that are configured exists
- Lock file is now created in more suitable directory 

Signed-off-by: Kristiyan Gostev <kristiyan.gostev@bosch.io>