### PR TITLE
ContainerFactory feature is not compliant with the Vorto model

### DIFF
--- a/containerm/things/features_container_factory.go
+++ b/containerm/things/features_container_factory.go
@@ -113,7 +113,11 @@ func (ctrFactory *containerFactoryFeature) featureOperationsHandler(operationNam
 		if err != nil {
 			return nil, client.NewMessagesParameterInvalidError(err.Error())
 		}
-		return ctrFactory.create(ctx, cArgs.ImageRef, cArgs.Start)
+		result, err := ctrFactory.create(ctx, cArgs.ImageRef, cArgs.Start)
+		if err != nil {
+			return nil, err
+		}
+		return result, nil
 	case containerFactoryFeatureOperationCreateWithConfig:
 		bytes, err := json.Marshal(args)
 		if err != nil {
@@ -124,7 +128,11 @@ func (ctrFactory *containerFactoryFeature) featureOperationsHandler(operationNam
 		if err != nil {
 			return nil, client.NewMessagesParameterInvalidError(err.Error())
 		}
-		return ctrFactory.createWithConfig(ctx, cArgs.ImageRef, cArgs.Name, cArgs.Config, cArgs.Start)
+		result, err := ctrFactory.createWithConfig(ctx, cArgs.ImageRef, cArgs.Name, cArgs.Config, cArgs.Start)
+		if err != nil {
+			return nil, err
+		}
+		return result, nil
 	default:
 		err := log.NewErrorf("unsupported operation %s", operationName)
 		log.ErrorErr(err, "unsupported operation %s", operationName)

--- a/containerm/things/features_container_factory.go
+++ b/containerm/things/features_container_factory.go
@@ -113,7 +113,7 @@ func (ctrFactory *containerFactoryFeature) featureOperationsHandler(operationNam
 		if err != nil {
 			return nil, client.NewMessagesParameterInvalidError(err.Error())
 		}
-		return nil, ctrFactory.create(ctx, cArgs.ImageRef, cArgs.Start)
+		return ctrFactory.create(ctx, cArgs.ImageRef, cArgs.Start)
 	case containerFactoryFeatureOperationCreateWithConfig:
 		bytes, err := json.Marshal(args)
 		if err != nil {
@@ -124,7 +124,7 @@ func (ctrFactory *containerFactoryFeature) featureOperationsHandler(operationNam
 		if err != nil {
 			return nil, client.NewMessagesParameterInvalidError(err.Error())
 		}
-		return nil, ctrFactory.createWithConfig(ctx, cArgs.ImageRef, cArgs.Name, cArgs.Config, cArgs.Start)
+		return ctrFactory.createWithConfig(ctx, cArgs.ImageRef, cArgs.Name, cArgs.Config, cArgs.Start)
 	default:
 		err := log.NewErrorf("unsupported operation %s", operationName)
 		log.ErrorErr(err, "unsupported operation %s", operationName)
@@ -132,9 +132,9 @@ func (ctrFactory *containerFactoryFeature) featureOperationsHandler(operationNam
 	}
 }
 
-func (ctrFactory *containerFactoryFeature) create(ctx context.Context, imageRef string, start bool) error {
+func (ctrFactory *containerFactoryFeature) create(ctx context.Context, imageRef string, start bool) (string, error) {
 	if imageRef == "" {
-		return log.NewError("imageRef must be set")
+		return "", log.NewError("imageRef must be set")
 	}
 	ctr := &types.Container{
 		Image: types.Image{
@@ -147,19 +147,19 @@ func (ctrFactory *containerFactoryFeature) create(ctx context.Context, imageRef 
 	)
 	if resCtr, err = ctrFactory.mgr.Create(ctx, ctr); err != nil {
 		log.ErrorErr(err, "failed to create container")
-		return err
+		return "", err
 	}
 	if start {
 		if err := ctrFactory.mgr.Start(ctx, resCtr.ID); err != nil {
 			log.ErrorErr(err, "could not auto start container ID = %s", ctr.ID)
 		}
 	}
-	return nil
+	return resCtr.ID, nil
 }
 
-func (ctrFactory *containerFactoryFeature) createWithConfig(ctx context.Context, imageRef, name string, cfg *configuration, start bool) error {
+func (ctrFactory *containerFactoryFeature) createWithConfig(ctx context.Context, imageRef, name string, cfg *configuration, start bool) (string, error) {
 	if imageRef == "" {
-		return log.NewError("imageRef must be set")
+		return "", log.NewError("imageRef must be set")
 	}
 	var ctr *types.Container
 	if cfg != nil {
@@ -176,12 +176,12 @@ func (ctrFactory *containerFactoryFeature) createWithConfig(ctx context.Context,
 	)
 	if resCtr, err = ctrFactory.mgr.Create(ctx, ctr); err != nil {
 		log.ErrorErr(err, "failed to create container")
-		return err
+		return "", err
 	}
 	if start {
 		if err := ctrFactory.mgr.Start(ctx, resCtr.ID); err != nil {
 			log.ErrorErr(err, "could not auto start container ID = %s", ctr.ID)
 		}
 	}
-	return nil
+	return resCtr.ID, nil
 }

--- a/containerm/things/features_container_factory.go
+++ b/containerm/things/features_container_factory.go
@@ -113,11 +113,7 @@ func (ctrFactory *containerFactoryFeature) featureOperationsHandler(operationNam
 		if err != nil {
 			return nil, client.NewMessagesParameterInvalidError(err.Error())
 		}
-		result, err := ctrFactory.create(ctx, cArgs.ImageRef, cArgs.Start)
-		if err != nil {
-			return nil, err
-		}
-		return result, nil
+		return ctrFactory.create(ctx, cArgs.ImageRef, cArgs.Start)
 	case containerFactoryFeatureOperationCreateWithConfig:
 		bytes, err := json.Marshal(args)
 		if err != nil {
@@ -128,11 +124,7 @@ func (ctrFactory *containerFactoryFeature) featureOperationsHandler(operationNam
 		if err != nil {
 			return nil, client.NewMessagesParameterInvalidError(err.Error())
 		}
-		result, err := ctrFactory.createWithConfig(ctx, cArgs.ImageRef, cArgs.Name, cArgs.Config, cArgs.Start)
-		if err != nil {
-			return nil, err
-		}
-		return result, nil
+		return ctrFactory.createWithConfig(ctx, cArgs.ImageRef, cArgs.Name, cArgs.Config, cArgs.Start)
 	default:
 		err := log.NewErrorf("unsupported operation %s", operationName)
 		log.ErrorErr(err, "unsupported operation %s", operationName)
@@ -140,9 +132,9 @@ func (ctrFactory *containerFactoryFeature) featureOperationsHandler(operationNam
 	}
 }
 
-func (ctrFactory *containerFactoryFeature) create(ctx context.Context, imageRef string, start bool) (string, error) {
+func (ctrFactory *containerFactoryFeature) create(ctx context.Context, imageRef string, start bool) (interface{}, error) {
 	if imageRef == "" {
-		return "", log.NewError("imageRef must be set")
+		return nil, log.NewError("imageRef must be set")
 	}
 	ctr := &types.Container{
 		Image: types.Image{
@@ -155,7 +147,7 @@ func (ctrFactory *containerFactoryFeature) create(ctx context.Context, imageRef 
 	)
 	if resCtr, err = ctrFactory.mgr.Create(ctx, ctr); err != nil {
 		log.ErrorErr(err, "failed to create container")
-		return "", err
+		return nil, err
 	}
 	if start {
 		if err := ctrFactory.mgr.Start(ctx, resCtr.ID); err != nil {
@@ -165,9 +157,9 @@ func (ctrFactory *containerFactoryFeature) create(ctx context.Context, imageRef 
 	return resCtr.ID, nil
 }
 
-func (ctrFactory *containerFactoryFeature) createWithConfig(ctx context.Context, imageRef, name string, cfg *configuration, start bool) (string, error) {
+func (ctrFactory *containerFactoryFeature) createWithConfig(ctx context.Context, imageRef, name string, cfg *configuration, start bool) (interface{}, error) {
 	if imageRef == "" {
-		return "", log.NewError("imageRef must be set")
+		return nil, log.NewError("imageRef must be set")
 	}
 	var ctr *types.Container
 	if cfg != nil {
@@ -184,7 +176,7 @@ func (ctrFactory *containerFactoryFeature) createWithConfig(ctx context.Context,
 	)
 	if resCtr, err = ctrFactory.mgr.Create(ctx, ctr); err != nil {
 		log.ErrorErr(err, "failed to create container")
-		return "", err
+		return nil, err
 	}
 	if start {
 		if err := ctrFactory.mgr.Start(ctx, resCtr.ID); err != nil {

--- a/containerm/things/features_container_factory_test.go
+++ b/containerm/things/features_container_factory_test.go
@@ -201,12 +201,10 @@ func TestContainerFactoryOperationsHandlerCreate(t *testing.T) {
 			setupThingMock(controller)
 			ctrFactory := newContainerFactoryFeature(mockContainerManager, mockEventsManager, mockThing, mockContainerStorage)
 
-			expectedRunErr := testCase.mockExecution(t)
+			expectedCtrID, expectedRunErr := testCase.mockExecution(t)
+			ctrID, resultErr := ctrFactory.(*containerFactoryFeature).featureOperationsHandler(testCase.operation, testCase.args)
 
-			result, resultErr := ctrFactory.(*containerFactoryFeature).featureOperationsHandler(testCase.operation, testCase.args)
-			if expectedRunErr == nil {
-				testutil.AssertEqual(t, testContainerID, result)
-			}
+			testutil.AssertEqual(t, expectedCtrID, ctrID)
 			testutil.AssertError(t, expectedRunErr, resultErr)
 		})
 	}
@@ -216,103 +214,103 @@ var (
 	testCreateOperationsHandlerInvalidArgs = make(chan int)
 )
 
-type mockExecCreate func(t *testing.T) error
+type mockExecCreate func(t *testing.T) (interface{}, error)
 
 // create without config mocks
 
-func mockExecContainerFactoryFeatureOperationsHandlerCreateNoErrors(t *testing.T) error {
+func mockExecContainerFactoryFeatureOperationsHandlerCreateNoErrors(t *testing.T) (interface{}, error) {
 	mockContainerManager.EXPECT().Create(gomock.Any(), testContainerToCreate).Times(1).Return(testContainerCreated, nil)
-	return nil
+	return testContainerCreated.ID, nil
 }
 
-func mockExecContainerFactoryFeatureOperationsHandlerCreateNoRefError(t *testing.T) error {
+func mockExecContainerFactoryFeatureOperationsHandlerCreateNoRefError(t *testing.T) (interface{}, error) {
 	mockContainerManager.EXPECT().Create(gomock.Any(), testContainerToCreate).Times(0)
-	return log.NewError("imageRef must be set")
+	return nil, log.NewError("imageRef must be set")
 }
 
-func mockExecContainerFactoryFeatureOperationsHandlerCreateErrorReturned(t *testing.T) error {
+func mockExecContainerFactoryFeatureOperationsHandlerCreateErrorReturned(t *testing.T) (interface{}, error) {
 	err := log.NewError("error while creating")
 	mockContainerManager.EXPECT().Create(gomock.Any(), testContainerToCreate).Times(1).Return(nil, err)
-	return err
+	return nil, err
 }
 
-func mockExecContainerFactoryFeatureOperationsHandlerCreateStartErrorReturned(t *testing.T) error {
+func mockExecContainerFactoryFeatureOperationsHandlerCreateStartErrorReturned(t *testing.T) (interface{}, error) {
 	err := log.NewError("error while starting")
 	mockContainerManager.EXPECT().Create(gomock.Any(), testContainerToCreate).Times(1).Return(testContainerCreated, nil)
 	mockContainerManager.EXPECT().Start(gomock.Any(), testContainerCreated.ID).Times(1).Return(err)
-	return nil
+	return testContainerCreated.ID, nil
 }
 
-func mockExecContainerFactoryFeatureOperationsHandlerCreateStartNoErrors(t *testing.T) error {
+func mockExecContainerFactoryFeatureOperationsHandlerCreateStartNoErrors(t *testing.T) (interface{}, error) {
 	mockContainerManager.EXPECT().Create(gomock.Any(), testContainerToCreate).Times(1).Return(testContainerCreated, nil)
 	mockContainerManager.EXPECT().Start(gomock.Any(), testContainerCreated.ID).Times(1).Return(nil)
-	return nil
+	return testContainerCreated.ID, nil
 }
 
-func mockExecContainerFactoryFeatureOperationsHandlerCreateInvalidArgsType(t *testing.T) error {
+func mockExecContainerFactoryFeatureOperationsHandlerCreateInvalidArgsType(t *testing.T) (interface{}, error) {
 	mockContainerManager.EXPECT().Create(gomock.Any(), gomock.Any()).Times(0)
 	mockContainerManager.EXPECT().Start(gomock.Any(), gomock.Any()).Times(0)
-	return client.NewMessagesParameterInvalidError("json: unsupported type: chan int")
+	return nil, client.NewMessagesParameterInvalidError("json: unsupported type: chan int")
 }
 
-func mockExecContainerFactoryFeatureOperationsHandlerCreateInvalidCreateArgs(t *testing.T) error {
+func mockExecContainerFactoryFeatureOperationsHandlerCreateInvalidCreateArgs(t *testing.T) (interface{}, error) {
 	mockContainerManager.EXPECT().Create(gomock.Any(), gomock.Any()).Times(0)
 	mockContainerManager.EXPECT().Start(gomock.Any(), gomock.Any()).Times(0)
-	return client.NewMessagesParameterInvalidError("json: cannot unmarshal string into Go value of type things.createArgs")
+	return nil, client.NewMessagesParameterInvalidError("json: cannot unmarshal string into Go value of type things.createArgs")
 }
 
 // create with config mocks
 
-func mockExecCreateStartWithConfigNoErrors(t *testing.T) error {
+func mockExecCreateStartWithConfigNoErrors(t *testing.T) (interface{}, error) {
 	mockContainerManager.EXPECT().Create(gomock.Any(), expectedCtr).Times(1).Return(testContainerCreated, nil)
 	mockContainerManager.EXPECT().Start(gomock.Any(), testContainerCreated.ID).Times(1).Return(nil)
-	return nil
+	return testContainerCreated.ID, nil
 }
-func mockExecCreateStartWithConfigNoImageRefError(t *testing.T) error {
+func mockExecCreateStartWithConfigNoImageRefError(t *testing.T) (interface{}, error) {
 	mockContainerManager.EXPECT().Create(gomock.Any(), gomock.Any()).Times(0)
 	mockContainerManager.EXPECT().Start(gomock.Any(), gomock.Any()).Times(0)
-	return log.NewError("imageRef must be set")
+	return nil, log.NewError("imageRef must be set")
 }
 
-func mockExecContainerFactoryFeatureOperationsHandlerCreateWithConfigErrorReturned(t *testing.T) error {
+func mockExecContainerFactoryFeatureOperationsHandlerCreateWithConfigErrorReturned(t *testing.T) (interface{}, error) {
 	err := log.NewError("error while creating")
 	mockContainerManager.EXPECT().Create(gomock.Any(), expectedCtr).Times(1).Return(nil, err)
-	return err
+	return nil, err
 }
 
-func mockExecContainerFactoryFeatureOperationsHandlerCreateWithConfigStartErrorReturned(t *testing.T) error {
+func mockExecContainerFactoryFeatureOperationsHandlerCreateWithConfigStartErrorReturned(t *testing.T) (interface{}, error) {
 	err := log.NewError("error while starting")
 	mockContainerManager.EXPECT().Create(gomock.Any(), expectedCtr).Times(1).Return(testContainerCreated, nil)
 	mockContainerManager.EXPECT().Start(gomock.Any(), testContainerCreated.ID).Times(1).Return(err)
-	return nil
+	return testContainerCreated.ID, nil
 }
 
-func mockExecContainerFactoryFeatureOperationsHandlerCreateWithConfigStartNoErrors(t *testing.T) error {
+func mockExecContainerFactoryFeatureOperationsHandlerCreateWithConfigStartNoErrors(t *testing.T) (interface{}, error) {
 	mockContainerManager.EXPECT().Create(gomock.Any(), expectedCtr).Times(1).Return(testContainerCreated, nil)
 	mockContainerManager.EXPECT().Start(gomock.Any(), testContainerCreated.ID).Times(1).Return(nil)
-	return nil
+	return testContainerCreated.ID, nil
 }
 
-func mockExecContainerFactoryFeatureOperationsHandlerCreateWithConfigNilConfig(t *testing.T) error {
+func mockExecContainerFactoryFeatureOperationsHandlerCreateWithConfigNilConfig(t *testing.T) (interface{}, error) {
 	mockContainerManager.EXPECT().Create(gomock.Any(), testContainerToCreate).Times(1).Return(testContainerCreated, nil)
 	mockContainerManager.EXPECT().Start(gomock.Any(), testContainerCreated.ID).Times(1).Return(nil)
-	return nil
+	return testContainerCreated.ID, nil
 }
 
-func mockExecContainerFactoryFeatureOperationsHandlerCreateWithConfigInvalidArgsType(t *testing.T) error {
+func mockExecContainerFactoryFeatureOperationsHandlerCreateWithConfigInvalidArgsType(t *testing.T) (interface{}, error) {
 	mockContainerManager.EXPECT().Create(gomock.Any(), gomock.Any()).Times(0)
 	mockContainerManager.EXPECT().Start(gomock.Any(), gomock.Any()).Times(0)
-	return client.NewMessagesParameterInvalidError("json: unsupported type: chan int")
+	return nil, client.NewMessagesParameterInvalidError("json: unsupported type: chan int")
 }
 
-func mockExecContainerFactoryFeatureOperationsHandlerCreateWithConfigInvalidCreateArgs(t *testing.T) error {
+func mockExecContainerFactoryFeatureOperationsHandlerCreateWithConfigInvalidCreateArgs(t *testing.T) (interface{}, error) {
 	mockContainerManager.EXPECT().Create(gomock.Any(), gomock.Any()).Times(0)
 	mockContainerManager.EXPECT().Start(gomock.Any(), gomock.Any()).Times(0)
-	return client.NewMessagesParameterInvalidError("json: cannot unmarshal string into Go value of type things.createWithConfigArgs")
+	return nil, client.NewMessagesParameterInvalidError("json: cannot unmarshal string into Go value of type things.createWithConfigArgs")
 }
 
-func mockExecContainerFactoryFeatureOperationsHandlerDefault(t *testing.T) error {
+func mockExecContainerFactoryFeatureOperationsHandlerDefault(t *testing.T) (interface{}, error) {
 	mockContainerManager.EXPECT().Create(gomock.Any(), gomock.Any()).Times(0)
 	mockContainerManager.EXPECT().Start(gomock.Any(), gomock.Any()).Times(0)
-	return client.NewMessagesSubjectNotFound(log.NewErrorf("unsupported operation %s", "unsupported-operation").Error())
+	return nil, client.NewMessagesSubjectNotFound(log.NewErrorf("unsupported operation %s", "unsupported-operation").Error())
 }

--- a/containerm/things/features_container_factory_test.go
+++ b/containerm/things/features_container_factory_test.go
@@ -106,7 +106,7 @@ func TestContainerFactoryOperationsHandlerCreate(t *testing.T) {
 		"test_container_factory_operations_handler_create_args_invalid": {
 			operation:     containerFactoryFeatureOperationCreate,
 			args:          testCreateOperationsHandlerInvalidArgs,
-			mockExecution: mockExecContainerFactoryFeatureOperationsHandlerCreategInvalidArgsType,
+			mockExecution: mockExecContainerFactoryFeatureOperationsHandlerCreateInvalidArgsType,
 		},
 		"test_container_factory_operations_handler_create_args_type": {
 			operation:     containerFactoryFeatureOperationCreate,
@@ -165,7 +165,8 @@ func TestContainerFactoryOperationsHandlerCreate(t *testing.T) {
 				ImageRef: testContainerImage,
 				Start:    true,
 				Config:   nil,
-			}, mockExecution: mockExecContainerFactoryFeatureOperationsHandlerCreateWithConfigNilConfig,
+			},
+			mockExecution: mockExecContainerFactoryFeatureOperationsHandlerCreateWithConfigNilConfig,
 		},
 		"test_container_factory_operations_handler_create_config_args_invalid": {
 			operation:     containerFactoryFeatureOperationCreateWithConfig,
@@ -203,7 +204,9 @@ func TestContainerFactoryOperationsHandlerCreate(t *testing.T) {
 			expectedRunErr := testCase.mockExecution(t)
 
 			result, resultErr := ctrFactory.(*containerFactoryFeature).featureOperationsHandler(testCase.operation, testCase.args)
-			testutil.AssertEqual(t, result, nil)
+			if expectedRunErr == nil {
+				testutil.AssertEqual(t, testContainerID, result)
+			}
 			testutil.AssertError(t, expectedRunErr, resultErr)
 		})
 	}
@@ -246,7 +249,7 @@ func mockExecContainerFactoryFeatureOperationsHandlerCreateStartNoErrors(t *test
 	return nil
 }
 
-func mockExecContainerFactoryFeatureOperationsHandlerCreategInvalidArgsType(t *testing.T) error {
+func mockExecContainerFactoryFeatureOperationsHandlerCreateInvalidArgsType(t *testing.T) error {
 	mockContainerManager.EXPECT().Create(gomock.Any(), gomock.Any()).Times(0)
 	mockContainerManager.EXPECT().Start(gomock.Any(), gomock.Any()).Times(0)
 	return client.NewMessagesParameterInvalidError("json: unsupported type: chan int")

--- a/integration/ctr_management_suite.go
+++ b/integration/ctr_management_suite.go
@@ -93,7 +93,7 @@ func (suite *ctrManagementSuite) createOperation(operation string, params map[st
 		if event.Topic.String() == suite.topicCreated {
 			ctrFeatureID = getCtrFeatureID(event.Path)
 			err := suite.assertCtrID(ctrFeatureID, string(ctrID))
-			require.NoError(suite.T(), err, "container feature ID is not expected")
+			require.NoError(suite.T(), err, "container ID is not expected")
 			definition, err := getCtrDefinition(event.Value)
 			require.NoError(suite.T(), err, "failed to parse property definition")
 			require.Equal(suite.T(), "com.bosch.iot.suite.edge.containers:Container:1.5.0", definition, "container feature definition is not expected")
@@ -151,7 +151,7 @@ func (suite *ctrManagementSuite) assertCtrID(ctrFeatureID, ctrID string) error {
 		return fmt.Errorf("failed to get container ID from container feature ID")
 	}
 	s1 := strings.Trim(ctrID, "\"")
-	require.Equal(suite.T(), s1, s[1], "container feature ID is not expected")
+	require.Equal(suite.T(), s1, s[1], "container ID is not expected")
 	return nil
 }
 

--- a/integration/ctr_management_suite.go
+++ b/integration/ctr_management_suite.go
@@ -49,14 +49,6 @@ func (suite *ctrManagementSuite) SetupCtrManagementSuite() {
 	suite.assertCtrFeatureDefinition(suite.ctrFactoryFeatureURL, "[\"com.bosch.iot.suite.edge.containers:ContainerFactory:1.3.0\"]")
 }
 
-func getCtrFeatureID(path string) string {
-	result := strings.Split(path, "/")
-	if len(result) < 3 {
-		return ""
-	}
-	return result[2]
-}
-
 func (suite *ctrManagementSuite) assertCtrFeatureDefinition(featureURL, expectedCtrDefinition string) {
 	actualCtrDefinition := featureURL + "/definition"
 	body, err := util.SendDigitalTwinRequest(suite.Cfg, http.MethodGet, actualCtrDefinition, nil)
@@ -86,7 +78,7 @@ func (suite *ctrManagementSuite) createWSConnection() *websocket.Conn {
 func (suite *ctrManagementSuite) createOperation(operation string, params map[string]interface{}) (*websocket.Conn, string) {
 	wsConnection := suite.createWSConnection()
 
-	_, err := util.ExecuteOperation(suite.Cfg, suite.ctrFactoryFeatureURL, operation, params)
+	ctrID, err := util.ExecuteOperation(suite.Cfg, suite.ctrFactoryFeatureURL, operation, params)
 	suite.closeOnError(wsConnection, err, "failed to execute the %s operation", operation)
 
 	var (
@@ -100,6 +92,8 @@ func (suite *ctrManagementSuite) createOperation(operation string, params map[st
 	err = util.ProcessWSMessages(suite.Cfg, wsConnection, func(event *protocol.Envelope) (bool, error) {
 		if event.Topic.String() == suite.topicCreated {
 			ctrFeatureID = getCtrFeatureID(event.Path)
+			err := suite.assertCtrID(ctrFeatureID, string(ctrID))
+			require.NoError(suite.T(), err, "container feature ID is not expected")
 			definition, err := getCtrDefinition(event.Value)
 			require.NoError(suite.T(), err, "failed to parse property definition")
 			require.Equal(suite.T(), "com.bosch.iot.suite.edge.containers:Container:1.5.0", definition, "container feature definition is not expected")
@@ -141,6 +135,24 @@ func (suite *ctrManagementSuite) createOperation(operation string, params map[st
 	})
 	suite.closeOnError(wsConnection, err, "failed to process creating the container feature")
 	return wsConnection, ctrFeatureID
+}
+
+func getCtrFeatureID(path string) string {
+	result := strings.Split(path, "/")
+	if len(result) < 3 {
+		return ""
+	}
+	return result[2]
+}
+
+func (suite *ctrManagementSuite) assertCtrID(ctrFeatureID, ctrID string) error {
+	s := strings.Split(ctrFeatureID, ":")
+	if len(s) < 2 {
+		return fmt.Errorf("failed to get container ID from container feature ID")
+	}
+	s1 := strings.Trim(ctrID, "\"")
+	require.Equal(suite.T(), s1, s[1], "container feature ID is not expected")
+	return nil
 }
 
 func parseMap(value interface{}) (map[string]interface{}, error) {


### PR DESCRIPTION
[#104] ContainerFactory feature is not compliant with the Vorto model

- fix create and createWithConfig operations are fixed to return the ID of the created container instance
- unit tests are fixed with these changes
- integration tests are fixed these changes

Signed-off-by: Guzgunova Antonia <Antonia.Guzgunova@bosch.io>