### PR TITLE
Provide integration test for the CLI start, stop and remove commands

### DIFF
--- a/integration/ctr_management_cli_test.go
+++ b/integration/ctr_management_cli_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 // Copyright (c) 2023 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
@@ -11,6 +9,8 @@
 // which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//go:build integration
+
 package integration
 
 import (

--- a/integration/testdata/remove-help.golden
+++ b/integration/testdata/remove-help.golden
@@ -1,0 +1,19 @@
+Remove a container and frees the associated resources.
+
+Usage:
+  kanto-cm remove <container-id>
+
+Examples:
+remove <container-id>
+ remove --name <container-name>
+ remove -n <container-name>
+
+Flags:
+  -f, --force         Force stopping before removing a container
+  -h, --help          help for remove
+  -n, --name string   Remove a container with a specific name.
+
+Global Flags:
+      --debug         Switch commands log level to DEBUG mode
+      --host string   Specify the address path to the Eclipse Kanto container management (default "/run/container-management/container-management.sock")
+      --timeout int   Specify the connection timeout in seconds to the Eclipse Kanto container management (default 30)

--- a/integration/testdata/remove-test.yaml
+++ b/integration/testdata/remove-test.yaml
@@ -30,7 +30,7 @@ expected:
   exitCode: 1
   err: "Error: The requested container with name = invalid was not found. Try using an ID instead."
 ---
-name: remove_existing_container
+name: remove_container_with_state_created
 setupCmd:
   - binary: kanto-cm
     args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
@@ -40,7 +40,7 @@ command:
 expected:
   exitCode: 0
 ---
-name: remove_running_container
+name: remove_container_with_state_running
 setupCmd:
   - binary: kanto-cm
     args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]

--- a/integration/testdata/remove-test.yaml
+++ b/integration/testdata/remove-test.yaml
@@ -1,0 +1,59 @@
+name: remove_help
+command:
+  binary: kanto-cm
+  args: ["remove", "-h"]
+expected:
+  exitCode: 0
+goldenFile: "remove-help.golden"
+---
+name: remove_no_args
+command:
+  binary: kanto-cm
+  args: ["remove"]
+expected:
+  exitCode: 1
+  err: "Error: You must provide either an ID or a name for the container via --name (-n)"
+---
+name: remove_invalid_id
+command:
+  binary: kanto-cm
+  args: ["remove", "invalid"]
+expected:
+  exitCode: 1
+  err: "Error: The requested container with ID = invalid was not found."
+---
+name: remove_invalid_name
+command:
+  binary: kanto-cm
+  args: ["remove", "-n", "invalid"]
+expected:
+  exitCode: 1
+  err: "Error: The requested container with name = invalid was not found. Try using an ID instead."
+---
+name: remove_existing_container
+setupCmd:
+  - binary: kanto-cm
+    args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
+command:
+  binary: kanto-cm
+  args: ["remove", "-n", "test-it"]
+expected:
+  exitCode: 0
+---
+name: remove_running_container
+setupCmd:
+  - binary: kanto-cm
+    args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
+  - binary: kanto-cm
+    args: ["start", "-n", "test-it"]
+command:
+  binary: kanto-cm
+  args: ["remove", "-n", "test-it"]
+expected:
+  exitCode: 1
+customResult:
+  type: REGEX
+  args: ["Error: rpc error: code = Unknown desc = container with id = [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12} is not stopped - must set the force flag to true to remove it"]
+onExit:
+  - binary: "kanto-cm"
+    args: ["remove","--host", "$KANTO_HOST", "-n", "test-it", "-f"]

--- a/integration/testdata/start-help.golden
+++ b/integration/testdata/start-help.golden
@@ -1,0 +1,20 @@
+Start a container.
+
+Usage:
+  kanto-cm start <container-id>
+
+Examples:
+start <container-id>
+ start --name <container-name>
+ start -n <container-name>
+
+Flags:
+      --a             Attach to the container's process STDOUT/STDERR and forward signals
+  -h, --help          help for start
+      --i             Enable interaction with the current container
+  -n, --name string   Start a container with a specific name.
+
+Global Flags:
+      --debug         Switch commands log level to DEBUG mode
+      --host string   Specify the address path to the Eclipse Kanto container management (default "/run/container-management/container-management.sock")
+      --timeout int   Specify the connection timeout in seconds to the Eclipse Kanto container management (default 30)

--- a/integration/testdata/start-test.yaml
+++ b/integration/testdata/start-test.yaml
@@ -30,7 +30,7 @@ expected:
   exitCode: 1
   err: "Error: The requested container with name = invalid was not found. Try using an ID instead."
 ---
-name: start_existing_container
+name: start_container_with_state_created
 setupCmd:
   - binary: kanto-cm
     args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
@@ -43,7 +43,7 @@ onExit:
   - binary: "kanto-cm"
     args: ["remove","--host", "$KANTO_HOST", "-n", "test-it", "-f"]
 ---
-name: start_already_started_container
+name: start_container_with_state_running
 setupCmd:
   - binary: kanto-cm
     args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]

--- a/integration/testdata/start-test.yaml
+++ b/integration/testdata/start-test.yaml
@@ -1,0 +1,62 @@
+name: start_help
+command:
+  binary: kanto-cm
+  args: ["start", "-h"]
+expected:
+  exitCode: 0
+goldenFile: "start-help.golden"
+---
+name: start_no_args
+command:
+  binary: kanto-cm
+  args: ["start"]
+expected:
+  exitCode: 1
+  err: "Error: You must provide either an ID or a name for the container via --name (-n)"
+---
+name: start_invalid_id
+command:
+  binary: kanto-cm
+  args: ["start", "invalid"]
+expected:
+  exitCode: 1
+  err: "Error: The requested container with ID = invalid was not found."
+---
+name: start_invalid_name
+command:
+  binary: kanto-cm
+  args: ["start", "-n", "invalid"]
+expected:
+  exitCode: 1
+  err: "Error: The requested container with name = invalid was not found. Try using an ID instead."
+---
+name: start_existing_container
+setupCmd:
+  - binary: kanto-cm
+    args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
+command:
+  binary: kanto-cm
+  args: ["start", "-n", "test-it"]
+expected:
+  exitCode: 0
+onExit:
+  - binary: "kanto-cm"
+    args: ["remove","--host", "$KANTO_HOST", "-n", "test-it", "-f"]
+---
+name: start_already_started_container
+setupCmd:
+  - binary: kanto-cm
+    args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
+  - binary: kanto-cm
+    args: ["start", "-n", "test-it"]
+command:
+  binary: kanto-cm
+  args: ["start", "-n", "test-it"]
+expected:
+  exitCode: 1
+customResult:
+  type: REGEX
+  args: ["Error: the container with ID = [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12} is already running - cannot start it again"]
+onExit:
+  - binary: "kanto-cm"
+    args: ["remove","--host", "$KANTO_HOST", "-n", "test-it", "-f"]

--- a/integration/testdata/stop-help.golden
+++ b/integration/testdata/stop-help.golden
@@ -1,0 +1,20 @@
+Stop a container.
+
+Usage:
+  kanto-cm stop <container-id>
+
+Examples:
+stop <container-id>
+ stop --name <container-name>
+ stop -n <container-name>
+
+Flags:
+  -f, --force           Whether to send a SIGKILL signal to the container's process if it does not finish within the timeout specified.
+  -h, --help            help for stop
+  -n, --name string     Stop a container with a specific name.
+  -s, --signal string   Stop a container using a specific signal. Signals could be specified by using their names or numbers, e.g. SIGINT or 2. (default "SIGTERM")
+
+Global Flags:
+      --debug         Switch commands log level to DEBUG mode
+      --host string   Specify the address path to the Eclipse Kanto container management (default "/run/container-management/container-management.sock")
+      --timeout int   Specify the connection timeout in seconds to the Eclipse Kanto container management (default 30)

--- a/integration/testdata/stop-test.yaml
+++ b/integration/testdata/stop-test.yaml
@@ -30,7 +30,7 @@ expected:
   exitCode: 1
   err: "Error: The requested container with name = invalid was not found. Try using an ID instead."
 ---
-name: stop_existing_container
+name: stop_container_with_state_running
 setupCmd:
   - binary: kanto-cm
     args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]

--- a/integration/testdata/stop-test.yaml
+++ b/integration/testdata/stop-test.yaml
@@ -1,0 +1,82 @@
+name: remove_help
+command:
+  binary: kanto-cm
+  args: ["stop", "-h"]
+expected:
+  exitCode: 0
+goldenFile: "stop-help.golden"
+---
+name: stop_no_args
+command:
+  binary: kanto-cm
+  args: ["stop"]
+expected:
+  exitCode: 1
+  err: "Error: You must provide either an ID or a name for the container via --name (-n)"
+---
+name: stop_invalid_id
+command:
+  binary: kanto-cm
+  args: ["start", "invalid"]
+expected:
+  exitCode: 1
+  err: "Error: The requested container with ID = invalid was not found."
+---
+name: stop_invalid_name
+command:
+  binary: kanto-cm
+  args: ["stop", "-n", "invalid"]
+expected:
+  exitCode: 1
+  err: "Error: The requested container with name = invalid was not found. Try using an ID instead."
+---
+name: stop_existing_container
+setupCmd:
+  - binary: kanto-cm
+    args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
+  - binary: kanto-cm
+    args: ["start", "-n", "test-it"]
+command:
+  binary: kanto-cm
+  args: ["stop", "-n", "test-it"]
+expected:
+  exitCode: 0
+onExit:
+  - binary: "kanto-cm"
+    args: ["remove","--host", "$KANTO_HOST", "-n", "test-it", "-f"]
+---
+name: stop_container_with_state_created
+setupCmd:
+  - binary: kanto-cm
+    args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
+command:
+  binary: kanto-cm
+  args: ["stop", "-n", "test-it"]
+expected:
+  exitCode: 1
+customResult:
+  type: REGEX
+  args: ["Error: rpc error: code = Unknown desc = cannot perform stop operation for container: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}, with state: Created"]
+onExit:
+  - binary: "kanto-cm"
+    args: ["remove","--host", "$KANTO_HOST", "-n", "test-it", "-f"]
+---
+name: stop_container_with_state_stopped
+setupCmd:
+  - binary: kanto-cm
+    args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
+  - binary: kanto-cm
+    args: ["start", "-n", "test-it"]
+  - binary: kanto-cm
+    args: ["stop", "-n", "test-it"]
+command:
+  binary: kanto-cm
+  args: ["stop", "-n", "test-it"]
+expected:
+  exitCode: 1
+customResult:
+  type: REGEX
+  args: ["Error: rpc error: code = Unknown desc = cannot perform stop operation for container: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}, with state: Stopped"]
+onExit:
+  - binary: "kanto-cm"
+    args: ["remove","--host", "$KANTO_HOST", "-n", "test-it", "-f"]


### PR DESCRIPTION
[#116] Provide integration test for the CLI start, stop and remove commands
- In addition, test for `kanto-cm -h` is also added

Signed-off-by: Kristiyan Gostev <kristiyan.gostev@bosch.com>