### PR TITLE
Provide integration test for the CLI sysinfo, logs and update commands

### DIFF
--- a/integration/framework/cli/cmd_base.go
+++ b/integration/framework/cli/cmd_base.go
@@ -31,7 +31,8 @@ import (
 const TestData = "testdata"
 
 var customResultDefaultFns = map[string]func(result icmd.Result, args ...string) assert.BoolOrComparison{
-	"REGEX": regex,
+	"REGEX":     regex,
+	"LOGS_JSON": logs,
 }
 
 // TestCaseCMD represents a command and expected result

--- a/integration/framework/cli/cmd_base_api.go
+++ b/integration/framework/cli/cmd_base_api.go
@@ -49,6 +49,11 @@ type Expected struct {
 //     customResult:
 //     name: REGEX
 //     args: ["([A-Za-z0-9]+(-[A-Za-z0-9]+)+)"]
+//   - LOGS_JSON - this function will validate that the stdout outputs consist of valid JSON entries and compare their count to args[0] if provided.
+//     example:
+//     customResult:
+//     name: LOGS_JSON
+//     args: ["5"]
 type CustomResult struct {
 	Type string   `yaml:"type"`
 	Args []string `yaml:"args"`

--- a/integration/framework/cli/cmd_base_custom_result.go
+++ b/integration/framework/cli/cmd_base_custom_result.go
@@ -47,6 +47,17 @@ func checkRegex(r *regexp.Regexp, s string) assert.BoolOrComparison {
 }
 
 func logs(result icmd.Result, args ...string) assert.BoolOrComparison {
+	var (
+		expectedLogEntries int
+		err                error
+	)
+	if len(args) > 0 {
+		expectedLogEntries, err = strconv.Atoi(args[0])
+		if err != nil {
+			return err
+		}
+	}
+
 	var logEntriesCount int
 	if result.Stdout() != "" {
 		lines := strings.Split(result.Stdout(), "\n")
@@ -63,13 +74,9 @@ func logs(result icmd.Result, args ...string) assert.BoolOrComparison {
 	}
 
 	if len(args) > 0 {
-		expectedLogEntries, err := strconv.Atoi(args[0])
-		if err != nil {
-			return err
-		}
 		if logEntriesCount != expectedLogEntries {
 			return log.NewErrorf("unexpected number of log entries: %d", logEntriesCount)
 		}
 	}
-	return nil
+	return true
 }

--- a/integration/testdata/logs-help.golden
+++ b/integration/testdata/logs-help.golden
@@ -1,0 +1,19 @@
+Print the logs for a container.
+
+Usage:
+  kanto-cm logs <container-id>
+
+Examples:
+logs <container-id>
+logs --name <container-name>
+logs -n <container-name>
+
+Flags:
+  -h, --help          help for logs
+  -n, --name string   Print the logs of a container with a specific name.
+  -t, --tail int32    Lines of recent log file to display. Setting it to -1 will return all logs. (default 100)
+
+Global Flags:
+      --debug         Switch commands log level to DEBUG mode
+      --host string   Specify the address path to the Eclipse Kanto container management (default "/run/container-management/container-management.sock")
+      --timeout int   Specify the connection timeout in seconds to the Eclipse Kanto container management (default 30)

--- a/integration/testdata/logs-test.yaml
+++ b/integration/testdata/logs-test.yaml
@@ -77,6 +77,8 @@ command:
   args: ["logs", "-n", "test-it"]
 expected:
   exitCode: 0
+customResult:
+  type: LOGS_JSON
 onExit:
   - binary: "kanto-cm"
     args: ["remove","--host", "$KANTO_HOST", "-n", "test-it", "-f"]

--- a/integration/testdata/logs-test.yaml
+++ b/integration/testdata/logs-test.yaml
@@ -1,67 +1,70 @@
-name: remove_help
+name: logs_help
 command:
   binary: kanto-cm
-  args: ["stop", "-h"]
+  args: ["logs", "-h"]
 expected:
   exitCode: 0
-goldenFile: "stop-help.golden"
+goldenFile: "logs-help.golden"
 ---
-name: stop_no_args
+name: logs_no_args
 command:
   binary: kanto-cm
-  args: ["stop"]
+  args: ["logs"]
 expected:
   exitCode: 1
   err: "Error: You must provide either an ID or a name for the container via --name (-n)"
 ---
-name: stop_invalid_id
+name: logs_invalid_id
 command:
   binary: kanto-cm
-  args: ["stop", "invalid"]
+  args: ["logs", "invalid"]
 expected:
   exitCode: 1
   err: "Error: The requested container with ID = invalid was not found."
 ---
-name: stop_invalid_name
+name: logs_invalid_name
 command:
   binary: kanto-cm
-  args: ["stop", "-n", "invalid"]
+  args: ["logs", "-n", "invalid"]
 expected:
   exitCode: 1
   err: "Error: The requested container with name = invalid was not found. Try using an ID instead."
 ---
-name: stop_container_with_state_running
+name: logs_of_container_with_state_created
+setupCmd:
+  - binary: kanto-cm
+    args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
+command:
+  binary: kanto-cm
+  args: ["logs", "-n", "test-it"]
+expected:
+  exitCode: 1
+  err: "Error: rpc error: code = Unknown desc = there are no logs for container with status \"Created\""
+onExit:
+  - binary: "kanto-cm"
+    args: ["remove","--host", "$KANTO_HOST", "-n", "test-it", "-f"]
+---
+name: logs_of_container_with_state_running
 setupCmd:
   - binary: kanto-cm
     args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
   - binary: kanto-cm
     args: ["start", "-n", "test-it"]
+  - binary: sleep
+    args: ["2"]
 command:
   binary: kanto-cm
-  args: ["stop", "-n", "test-it"]
+  args: ["logs", "-n", "test-it", "-t", "5"]
 expected:
   exitCode: 0
-onExit:
-  - binary: "kanto-cm"
-    args: ["remove","--host", "$KANTO_HOST", "-n", "test-it", "-f"]
----
-name: stop_container_with_state_created
-setupCmd:
-  - binary: kanto-cm
-    args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
-command:
-  binary: kanto-cm
-  args: ["stop", "-n", "test-it"]
-expected:
-  exitCode: 1
 customResult:
-  type: REGEX
-  args: ["Error: rpc error: code = Unknown desc = cannot perform stop operation for container: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}, with state: Created"]
+  type: LOGS_JSON
+  args: ["5"]
 onExit:
   - binary: "kanto-cm"
     args: ["remove","--host", "$KANTO_HOST", "-n", "test-it", "-f"]
 ---
-name: stop_container_with_state_stopped
+name: logs_of_container_with_state_stopped
 setupCmd:
   - binary: kanto-cm
     args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
@@ -71,12 +74,9 @@ setupCmd:
     args: ["stop", "-n", "test-it"]
 command:
   binary: kanto-cm
-  args: ["stop", "-n", "test-it"]
+  args: ["logs", "-n", "test-it"]
 expected:
-  exitCode: 1
-customResult:
-  type: REGEX
-  args: ["Error: rpc error: code = Unknown desc = cannot perform stop operation for container: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}, with state: Stopped"]
+  exitCode: 0
 onExit:
   - binary: "kanto-cm"
     args: ["remove","--host", "$KANTO_HOST", "-n", "test-it", "-f"]

--- a/integration/testdata/sysinfo-help.golden
+++ b/integration/testdata/sysinfo-help.golden
@@ -1,0 +1,15 @@
+Show information about the container management runtime and its environment.
+
+Usage:
+  kanto-cm sysinfo
+
+Examples:
+sysinfo
+
+Flags:
+  -h, --help   help for sysinfo
+
+Global Flags:
+      --debug         Switch commands log level to DEBUG mode
+      --host string   Specify the address path to the Eclipse Kanto container management (default "/run/container-management/container-management.sock")
+      --timeout int   Specify the connection timeout in seconds to the Eclipse Kanto container management (default 30)

--- a/integration/testdata/sysinfo-test.yaml
+++ b/integration/testdata/sysinfo-test.yaml
@@ -1,0 +1,17 @@
+name: sysinfo_help
+command:
+  binary: kanto-cm
+  args: ["sysinfo", "-h"]
+expected:
+  exitCode: 0
+goldenFile: "sysinfo-help.golden"
+---
+name: sysinfo
+command:
+  binary: kanto-cm
+  args: ["sysinfo"]
+expected:
+  exitCode: 0
+customResult:
+  type: REGEX
+  args: ["Engine v[^ ]*, API v[^ ]*, \\(build [^ ]* [^ ]*\\) [\\r?\\n]CLI v[^ ]*, API v[^ ]*, \\(build [^ ]* [^ ]*\\) [\\r?\\n]"]

--- a/integration/testdata/update-help.golden
+++ b/integration/testdata/update-help.golden
@@ -1,0 +1,33 @@
+Update a container without recreating it. The provided configurations will be merged with the current one.
+
+Usage:
+  kanto-cm update <container-id>
+
+Examples:
+update <container-id>
+update -n <container-name>
+
+
+Flags:
+  -h, --help                        help for update
+  -m, --memory string               Updates the max amount of memory the container can use in the form of 200m, 1.2g.
+                                    Use -1, to remove the memory usage limit.
+      --memory-reservation string   Updates the soft memory limitation in the form of 200m, 1.2g.
+                                    Use -1, to remove the reservation memory limit.
+      --memory-swap string          Updates the total amount of memory + swap that the container can use in the form of 200m, 1.2g.
+                                    Use -1, to remove the swap memory limit.
+  -n, --name string                 Updates the container with a specific name.
+      --rp string                   Updates the restart policy for the container. The policy will be applied when the container exits. Supported restart policies are - no, always, unless-stopped, on-failure. 
+                                    no - no attempts to restart the container for any reason will be made 
+                                    always - an attempt to restart the container will be made each time the container exits regardless of the exit code 
+                                    unless-stopped - restart attempts will be made only if the container has not been stopped by the user 
+                                    on-failure - restart attempts will be made if the container exits with an exit code != 0; 
+                                    the additional flags (--rp-cnt and --rp-to) apply only for this policy; if max retry count is not provided - the system will retry until it succeeds endlessly 
+                                    
+      --rp-cnt int                  Updates the number of retries that will be made to restart the container on exit if the policy is on-failure (default -2147483648)
+      --rp-to int                   Updates the time out period in seconds for each retry that will be made to restart the container on exit if the policy is set to on-failure (default -9223372036854775808)
+
+Global Flags:
+      --debug         Switch commands log level to DEBUG mode
+      --host string   Specify the address path to the Eclipse Kanto container management (default "/run/container-management/container-management.sock")
+      --timeout int   Specify the connection timeout in seconds to the Eclipse Kanto container management (default 30)

--- a/integration/testdata/update-test.yaml
+++ b/integration/testdata/update-test.yaml
@@ -1,36 +1,36 @@
-name: remove_help
+name: update_help
 command:
   binary: kanto-cm
-  args: ["stop", "-h"]
+  args: ["update", "-h"]
 expected:
   exitCode: 0
-goldenFile: "stop-help.golden"
+goldenFile: "update-help.golden"
 ---
-name: stop_no_args
+name: update_no_args
 command:
   binary: kanto-cm
-  args: ["stop"]
+  args: ["update"]
 expected:
   exitCode: 1
   err: "Error: You must provide either an ID or a name for the container via --name (-n)"
 ---
-name: stop_invalid_id
+name: update_invalid_id
 command:
   binary: kanto-cm
-  args: ["stop", "invalid"]
+  args: ["update", "invalid"]
 expected:
   exitCode: 1
   err: "Error: The requested container with ID = invalid was not found."
 ---
-name: stop_invalid_name
+name: update_invalid_name
 command:
   binary: kanto-cm
-  args: ["stop", "-n", "invalid"]
+  args: ["update", "-n", "invalid"]
 expected:
   exitCode: 1
   err: "Error: The requested container with name = invalid was not found. Try using an ID instead."
 ---
-name: stop_container_with_state_running
+name: update_container_with_state_running
 setupCmd:
   - binary: kanto-cm
     args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
@@ -38,45 +38,39 @@ setupCmd:
     args: ["start", "-n", "test-it"]
 command:
   binary: kanto-cm
-  args: ["stop", "-n", "test-it"]
+  args: ["update", "-n", "test-it", "--rp", "no"]
 expected:
   exitCode: 0
 onExit:
   - binary: "kanto-cm"
     args: ["remove","--host", "$KANTO_HOST", "-n", "test-it", "-f"]
 ---
-name: stop_container_with_state_created
+name: update_container_with_state_created
 setupCmd:
   - binary: kanto-cm
     args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
 command:
   binary: kanto-cm
-  args: ["stop", "-n", "test-it"]
+  args: ["update", "-n", "test-it", "--rp", "no"]
 expected:
-  exitCode: 1
-customResult:
-  type: REGEX
-  args: ["Error: rpc error: code = Unknown desc = cannot perform stop operation for container: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}, with state: Created"]
+  exitCode: 0
 onExit:
   - binary: "kanto-cm"
     args: ["remove","--host", "$KANTO_HOST", "-n", "test-it", "-f"]
 ---
-name: stop_container_with_state_stopped
+name: update_container_with_state_stopped
 setupCmd:
   - binary: kanto-cm
     args: ["create", "--host", "$KANTO_HOST", "-n", "test-it", "docker.io/library/influxdb:1.8.4"]
   - binary: kanto-cm
-    args: ["start", "-n", "test-it"]
+    args: [ "start", "-n", "test-it" ]
   - binary: kanto-cm
-    args: ["stop", "-n", "test-it"]
+    args: [ "stop", "-n", "test-it" ]
 command:
   binary: kanto-cm
-  args: ["stop", "-n", "test-it"]
+  args: ["update", "-n", "test-it", "--rp", "no"]
 expected:
-  exitCode: 1
-customResult:
-  type: REGEX
-  args: ["Error: rpc error: code = Unknown desc = cannot perform stop operation for container: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}, with state: Stopped"]
+  exitCode: 0
 onExit:
   - binary: "kanto-cm"
     args: ["remove","--host", "$KANTO_HOST", "-n", "test-it", "-f"]


### PR DESCRIPTION
[#119] Provide integration test for the CLI sysinfo, logs and update commands

 - added integration tests for sysinfo, update and logs CLI commands
 - implemented custom result function for logs command
 - fixed stop_invalid_id test

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov3@bosch.io>