### PR TITLE
Implemented automated update of containers via descriptor files

### DIFF
--- a/containerm/daemon/daemon_command.go
+++ b/containerm/daemon/daemon_command.go
@@ -31,8 +31,10 @@ func setupCommandFlags(cmd *cobra.Command) {
 	flagSet.BoolVar(&cfg.Log.Syslog, "log-syslog", cfg.Log.Syslog, "Enable logging in the local syslog (e.g. /dev/log, /var/run/syslog, /var/run/log)")
 
 	// init deployment flags
+	flagSet.BoolVar(&cfg.DeploymentManagerConfig.DeploymentEnable, "deployment-enable", cfg.DeploymentManagerConfig.DeploymentEnable, "Enable the deployment service providing installation/update of containers via the container descriptor files")
+	flagSet.StringVar(&cfg.DeploymentManagerConfig.DeploymentMode, "deployment-mode", cfg.DeploymentManagerConfig.DeploymentMode, "Specify the operation mode of deployment manager service, e.g. if it shall run on its initial run only or on every start of container management")
 	flagSet.StringVar(&cfg.DeploymentManagerConfig.DeploymentMetaPath, "deployment-home-dir", cfg.DeploymentManagerConfig.DeploymentMetaPath, "Specify the root directory of the deployment manager service")
-	flagSet.StringVar(&cfg.DeploymentManagerConfig.DeploymentInitPath, "deployment-init-dir", cfg.DeploymentManagerConfig.DeploymentInitPath, "Specify a directory for initial containers deploy.")
+	flagSet.StringVar(&cfg.DeploymentManagerConfig.DeploymentCtrPath, "deployment-ctr-dir", cfg.DeploymentManagerConfig.DeploymentCtrPath, "Specify a directory with container descriptor files for automated deployment")
 
 	// init container manager flags
 	flagSet.StringVar(&cfg.ManagerConfig.MgrMetaPath, "cm-home-dir", cfg.ManagerConfig.MgrMetaPath, "Specify the root directory of the container manager service")

--- a/containerm/daemon/daemon_config.go
+++ b/containerm/daemon/daemon_config.go
@@ -63,8 +63,10 @@ type containerRuntimeConfig struct {
 
 // deployment manager config
 type deploymentManagerConfig struct {
+	DeploymentEnable   bool   `json:"enable,omitempty"`
+	DeploymentMode     string `json:"mode,omitempty"`
 	DeploymentMetaPath string `json:"home_dir,omitempty"`
-	DeploymentInitPath string `json:"init_dir,omitempty"`
+	DeploymentCtrPath  string `json:"ctr_dir,omitempty"`
 }
 
 func (cfg *containerRuntimeConfig) UnmarshalJSON(data []byte) error {

--- a/containerm/daemon/daemon_config_default.go
+++ b/containerm/daemon/daemon_config_default.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/eclipse-kanto/container-management/containerm/containers/types"
 	"github.com/eclipse-kanto/container-management/containerm/ctr"
+	"github.com/eclipse-kanto/container-management/containerm/deployment"
 	"github.com/eclipse-kanto/container-management/containerm/log"
 	"github.com/eclipse-kanto/container-management/containerm/network"
 	"github.com/eclipse-kanto/container-management/containerm/things"
@@ -88,8 +89,10 @@ const (
 	thingsUnsubscribeTimeoutDefault          = 5000
 
 	// default deployment config
-	deploymentMetaPathDefault    = managerMetaPathDefault
-	deploymentInitialPathDefault = "/etc/container-management/containers"
+	deploymentEnableDefault   = true
+	deploymentModeDefault     = deployment.ModeUpdate
+	deploymentMetaPathDefault = managerMetaPathDefault
+	deploymentCtrPathDefault  = "/etc/container-management/containers"
 )
 
 var (
@@ -168,8 +171,10 @@ func getDefaultInstance() *config {
 			},
 		},
 		DeploymentManagerConfig: &deploymentManagerConfig{
+			DeploymentEnable:   deploymentEnableDefault,
+			DeploymentMode:     deploymentModeDefault,
 			DeploymentMetaPath: deploymentMetaPathDefault,
-			DeploymentInitPath: deploymentInitialPathDefault,
+			DeploymentCtrPath:  deploymentCtrPathDefault,
 		},
 	}
 }

--- a/containerm/daemon/daemon_config_default.go
+++ b/containerm/daemon/daemon_config_default.go
@@ -90,7 +90,7 @@ const (
 
 	// default deployment config
 	deploymentEnableDefault   = true
-	deploymentModeDefault     = deployment.ModeUpdate
+	deploymentModeDefault     = string(deployment.UpdateMode)
 	deploymentMetaPathDefault = managerMetaPathDefault
 	deploymentCtrPathDefault  = "/etc/container-management/containers"
 )

--- a/containerm/daemon/daemon_config_util.go
+++ b/containerm/daemon/daemon_config_util.go
@@ -116,8 +116,9 @@ func extractThingsOptions(daemonConfig *config) []things.ContainerThingsManagerO
 
 func extractDeploymentMgrOptions(daemonConfig *config) []deployment.Opt {
 	return []deployment.Opt{
+		deployment.WithMode(daemonConfig.DeploymentManagerConfig.DeploymentMode),
 		deployment.WithMetaPath(daemonConfig.DeploymentManagerConfig.DeploymentMetaPath),
-		deployment.WithInitialDeployPath(daemonConfig.DeploymentManagerConfig.DeploymentInitPath),
+		deployment.WithCtrPath(daemonConfig.DeploymentManagerConfig.DeploymentCtrPath),
 	}
 }
 
@@ -303,8 +304,10 @@ func dumpThingsClient(configInstance *config) {
 
 func dumpDeploymentManager(configInstance *config) {
 	if configInstance.DeploymentManagerConfig != nil {
+		log.Debug("[daemon_cfg][deployment-enable] : %v", configInstance.DeploymentManagerConfig.DeploymentEnable)
+		log.Debug("[daemon_cfg][deployment-mode] : %s", configInstance.DeploymentManagerConfig.DeploymentMode)
 		log.Debug("[daemon_cfg][deployment-home-dir] : %s", configInstance.DeploymentManagerConfig.DeploymentMetaPath)
-		log.Debug("[daemon_cfg][deployment-init-dir] : %s", configInstance.DeploymentManagerConfig.DeploymentInitPath)
+		log.Debug("[daemon_cfg][deployment-ctr-dir] : %s", configInstance.DeploymentManagerConfig.DeploymentCtrPath)
 	}
 }
 

--- a/containerm/daemon/daemon_internal_init.go
+++ b/containerm/daemon/daemon_internal_init.go
@@ -54,7 +54,11 @@ func (d *daemon) init() {
 	}
 
 	//init deployment manager service
-	initService(ctx, d, registrationsMap, registry.DeploymentManagerService)
+	if daemonConfig.DeploymentManagerConfig.DeploymentEnable {
+		initService(ctx, d, registrationsMap, registry.DeploymentManagerService)
+	} else {
+		log.Info("Deployment Manager is disabled - no Deployment Manager Services will be registered. If you would like to enable Deployment support, please, reconfigure deployment-enable to true")
+	}
 
 	//init grpc services
 	initService(ctx, d, registrationsMap, registry.GRPCService)

--- a/containerm/daemon/daemon_test.go
+++ b/containerm/daemon/daemon_test.go
@@ -389,12 +389,20 @@ func TestSetCommandFlags(t *testing.T) {
 			flag:         "things-conn-client-key",
 			expectedType: reflect.String.String(),
 		},
+		"test_flags_deployment-enable": {
+			flag:         "deployment-enable",
+			expectedType: reflect.Bool.String(),
+		},
+		"test_flags_deployment-mode": {
+			flag:         "deployment-mode",
+			expectedType: reflect.String.String(),
+		},
 		"test_flags_deployment-home-dir": {
 			flag:         "deployment-home-dir",
 			expectedType: reflect.String.String(),
 		},
-		"test_flags_deployment-init-dir": {
-			flag:         "deployment-init-dir",
+		"test_flags_deployment-ctr-dir": {
+			flag:         "deployment-ctr-dir",
 			expectedType: reflect.String.String(),
 		},
 	}

--- a/containerm/deployment/deployment.go
+++ b/containerm/deployment/deployment.go
@@ -40,12 +40,13 @@ func init() {
 }
 
 type deploymentMgr struct {
-	metaPath          string
-	initialDeployPath string
-	ctrMgr            mgr.ContainerManager
-	deploymentLock    sync.RWMutex
-	disposeLock       sync.RWMutex
-	disposed          bool
+	mode           string
+	metaPath       string
+	ctrPath        string
+	ctrMgr         mgr.ContainerManager
+	deploymentLock sync.RWMutex
+	disposeLock    sync.RWMutex
+	disposed       bool
 }
 
 func (d *deploymentMgr) InitialDeploy(ctx context.Context) error {
@@ -69,7 +70,7 @@ func (d *deploymentMgr) InitialDeploy(ctx context.Context) error {
 	}
 
 	var fileInfo os.FileInfo
-	if fileInfo, err = os.Stat(d.initialDeployPath); err != nil {
+	if fileInfo, err = os.Stat(d.ctrPath); err != nil {
 		if os.IsNotExist(err) {
 			log.Debug("the initial containers deploy directory does not exist - will exit deploying")
 			return nil
@@ -78,11 +79,11 @@ func (d *deploymentMgr) InitialDeploy(ctx context.Context) error {
 	}
 
 	if !fileInfo.IsDir() {
-		return log.NewErrorf("the initial containers deploy path = %s is not a directory", d.initialDeployPath)
+		return log.NewErrorf("the initial containers deploy path = %s is not a directory", d.ctrPath)
 	}
 
 	var ctrs []*types.Container
-	err = filepath.WalkDir(d.initialDeployPath, func(path string, entry fs.DirEntry, err error) error {
+	err = filepath.WalkDir(d.ctrPath, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/containerm/deployment/deployment.go
+++ b/containerm/deployment/deployment.go
@@ -40,7 +40,7 @@ func init() {
 }
 
 type deploymentMgr struct {
-	mode           string
+	mode           Mode
 	metaPath       string
 	ctrPath        string
 	ctrMgr         mgr.ContainerManager
@@ -55,7 +55,7 @@ func (d *deploymentMgr) Deploy(ctx context.Context) error {
 		if err = util.MkDir(deploymentMetaPath); err != nil {
 			return err
 		}
-	} else if d.mode == ModeInitialDeploy {
+	} else if d.mode == InitialDeployMode {
 		log.Debug("not a first run, will skip initial containers deploy")
 		return nil
 	}
@@ -64,7 +64,7 @@ func (d *deploymentMgr) Deploy(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if d.mode == ModeInitialDeploy && len(listCtrs) > 0 {
+	if d.mode == InitialDeployMode && len(listCtrs) > 0 {
 		log.Debug("there are loaded container resources, will skip initial containers deploy")
 		return nil
 	}
@@ -101,7 +101,7 @@ func (d *deploymentMgr) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	if d.mode == ModeInitialDeploy {
+	if d.mode == InitialDeployMode {
 		go d.processInitialDeploy(ctx, ctrs)
 	} else {
 		go d.processUpdate(ctx, listCtrs, ctrs)

--- a/containerm/deployment/deployment_api.go
+++ b/containerm/deployment/deployment_api.go
@@ -26,8 +26,8 @@ const (
 // Manager represents the container deployment manager abstraction
 type Manager interface {
 
-	// InitialDeploy initially deploys containers described in configured local path
-	InitialDeploy(ctx context.Context) error
+	// Deploy initially deploys or updates containers described in configured local path
+	Deploy(ctx context.Context) error
 
 	// Dispose stops running deployments
 	Dispose(ctx context.Context) error

--- a/containerm/deployment/deployment_api.go
+++ b/containerm/deployment/deployment_api.go
@@ -16,11 +16,14 @@ import (
 	"context"
 )
 
+// Mode indicates available deployment modes
+type Mode string
+
 const (
-	// ModeInitialDeploy means that the deployment service will deploy new containers only on initial start of container management
-	ModeInitialDeploy = "init"
-	// ModeUpdate means that the deployment service will deploy new containers and/or update existing containers on each start of container management
-	ModeUpdate = "update"
+	// InitialDeployMode means that the deployment service will deploy new containers only on initial start of container management
+	InitialDeployMode Mode = "init"
+	// UpdateMode means that the deployment service will deploy new containers and/or update existing containers on each start of container management
+	UpdateMode Mode = "update"
 )
 
 // Manager represents the container deployment manager abstraction

--- a/containerm/deployment/deployment_api.go
+++ b/containerm/deployment/deployment_api.go
@@ -16,6 +16,13 @@ import (
 	"context"
 )
 
+const (
+	// ModeInitialDeploy means that the deployment service will deploy new containers only on initial start of container management
+	ModeInitialDeploy = "init"
+	// ModeUpdate means that the deployment service will deploy new containers and/or update existing containers on each start of container management
+	ModeUpdate = "update"
+)
+
 // Manager represents the container deployment manager abstraction
 type Manager interface {
 

--- a/containerm/deployment/deployment_internal.go
+++ b/containerm/deployment/deployment_internal.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/eclipse-kanto/container-management/containerm/containers/types"
 	"github.com/eclipse-kanto/container-management/containerm/log"
+	"github.com/eclipse-kanto/container-management/containerm/mgr"
+	"github.com/eclipse-kanto/container-management/containerm/util"
 )
 
 func (d *deploymentMgr) processInitialDeploy(ctx context.Context, containers []*types.Container) {
@@ -33,17 +35,134 @@ func (d *deploymentMgr) processInitialDeploy(ctx context.Context, containers []*
 		}
 		d.disposeLock.RUnlock()
 
-		ctr, createErr := d.ctrMgr.Create(ctx, container)
-		if createErr != nil {
-			log.WarnErr(createErr, "could not create container with name = %s and image name = %s", container.Name, container.Image.Name)
-		} else {
-			log.Debug("successfully created container with ID = %s", ctr.ID)
-			if startErr := d.ctrMgr.Start(ctx, ctr.ID); startErr != nil {
-				log.WarnErr(startErr, "could not start container with ID = %s", ctr.ID)
-			} else {
-				log.Debug("successfully started container with ID = %s", ctr.ID)
-			}
-		}
+		createAndStartContainer(ctx, d.ctrMgr, container)
 	}
 	log.Debug("finished initial containers deploy")
+}
+
+func (d *deploymentMgr) processUpdate(ctx context.Context, existing []*types.Container, target []*types.Container) {
+	d.deploymentLock.Lock()
+	defer d.deploymentLock.Unlock()
+
+	log.Debug("starting containers update")
+
+	mapCurrent := util.AsNamedMap(existing)
+
+	for _, desired := range target {
+		d.disposeLock.RLock()
+		if d.disposed {
+			d.disposeLock.RUnlock()
+			log.Warn("interrupted containers update")
+			return
+		}
+		d.disposeLock.RUnlock()
+
+		util.FillDefaults(desired)
+		current := mapCurrent[desired.Name]
+
+		action := util.DetermineUpdateAction(current, desired)
+		switch action {
+		case util.ActionCheck:
+			ensureContainerRunning(ctx, d.ctrMgr, current)
+		case util.ActionCreate:
+			createAndStartContainer(ctx, d.ctrMgr, desired)
+		case util.ActionRecreate:
+			recreateAndStartContainer(ctx, d.ctrMgr, current, desired)
+		case util.ActionUpdate:
+			updateContainer(ctx, d.ctrMgr, current, desired)
+		}
+	}
+	log.Debug("finished containers update")
+}
+
+func ensureContainerRunning(ctx context.Context, ctrMgr mgr.ContainerManager, container *types.Container) {
+	if container.State.Running {
+		log.Debug("container with ID = %s, name = %s and image name = %s is already running, nothing to do", container.ID, container.Name, container.Image.Name)
+	} else if container.State.Paused {
+		unpauseContainer(ctx, ctrMgr, container)
+	} else {
+		startContainer(ctx, ctrMgr, container)
+	}
+}
+
+func createAndStartContainer(ctx context.Context, ctrMgr mgr.ContainerManager, container *types.Container) {
+	ctr, createErr := ctrMgr.Create(ctx, container)
+	if createErr != nil {
+		log.WarnErr(createErr, "could not create container with name = %s and image name = %s", container.Name, container.Image.Name)
+	} else {
+		log.Debug("successfully created container with ID = %s, name = %s and image name = %s", ctr.ID, ctr.Name, ctr.Image.Name)
+		startContainer(ctx, ctrMgr, ctr)
+	}
+}
+
+func recreateAndStartContainer(ctx context.Context, ctrMgr mgr.ContainerManager, current *types.Container, desired *types.Container) {
+	ctr, createErr := ctrMgr.Create(ctx, desired)
+	if createErr != nil {
+		log.WarnErr(createErr, "could not create new container with name = %s and image name = %s", desired.Name, desired.Image.Name)
+		return
+	}
+	log.Debug("successfully created new container with ID = %s, name = %s and image name = %s", ctr.ID, ctr.Name, ctr.Image.Name)
+	stopContainer(ctx, ctrMgr, current)
+	if startErr := startContainer(ctx, ctrMgr, ctr); startErr != nil {
+		log.Warn("restoring old container with ID = %s, name = %s and image name = %s", current.ID, current.Name, current.Image.Name)
+		startContainer(ctx, ctrMgr, current)
+		log.Warn("removing not-started new container with ID = %s, name = %s and image name = %s", ctr.ID, ctr.Name, ctr.Image.Name)
+		removeContainer(ctx, ctrMgr, ctr)
+	} else {
+		log.Debug("removing old container with ID = %s, name = %s and image name = %s", current.ID, current.Name, current.Image.Name)
+		removeContainer(ctx, ctrMgr, current)
+	}
+}
+
+func updateContainer(ctx context.Context, ctrMgr mgr.ContainerManager, current *types.Container, desired *types.Container) {
+	updateOpts := &types.UpdateOpts{
+		RestartPolicy: desired.HostConfig.RestartPolicy,
+		Resources:     desired.HostConfig.Resources,
+	}
+	if updateErr := ctrMgr.Update(ctx, current.ID, updateOpts); updateErr != nil {
+		log.WarnErr(updateErr, "could not update container with ID = %s, name = %s and image name = %s", current.ID, current.Name, current.Image.Name)
+	} else {
+		log.Debug("successfully updated container with ID = %s, name = %s and image name = %s", current.ID, current.Name, current.Image.Name)
+	}
+}
+
+func startContainer(ctx context.Context, ctrMgr mgr.ContainerManager, container *types.Container) error {
+	if startErr := ctrMgr.Start(ctx, container.ID); startErr != nil {
+		log.WarnErr(startErr, "could not start container with ID = %s, name = %s and image name = %s", container.ID, container.Name, container.Image.Name)
+		return startErr
+	}
+	log.Debug("successfully started container with ID = %s, name = %s and image name = %s", container.ID, container.Name, container.Image.Name)
+	return nil
+}
+
+func unpauseContainer(ctx context.Context, ctrMgr mgr.ContainerManager, container *types.Container) {
+	if unpauseErr := ctrMgr.Unpause(ctx, container.ID); unpauseErr != nil {
+		log.WarnErr(unpauseErr, "could not unpause container with ID = %s, name = %s and image name = %s", container.ID, container.Name, container.Image.Name)
+	} else {
+		log.Debug("successfully unpaused container with ID = %s, name = %s and image name = %s", container.ID, container.Name, container.Image.Name)
+	}
+}
+
+func stopContainer(ctx context.Context, ctrMgr mgr.ContainerManager, container *types.Container) {
+	if !util.IsContainerRunningOrPaused(container) {
+		log.Debug("container with ID = %s, name = %s and image name = %s is not running, nor paused", container.ID, container.Name, container.Image.Name)
+		return
+	}
+	stopOpts := &types.StopOpts{
+		Force:  true,
+		Signal: "SIGTERM",
+	}
+	if stopErr := ctrMgr.Stop(ctx, container.ID, stopOpts); stopErr != nil {
+		log.WarnErr(stopErr, "could not stop container with ID = %s, name = %s and image name = %s", container.ID, container.Name, container.Image.Name)
+	} else {
+		log.Debug("successfully stopped container with ID = %s, name = %s and image name = %s", container.ID, container.Name, container.Image.Name)
+	}
+}
+
+func removeContainer(ctx context.Context, ctrMgr mgr.ContainerManager, container *types.Container) {
+	if removeErr := ctrMgr.Remove(ctx, container.ID, true); removeErr != nil {
+		log.WarnErr(removeErr, "could not remove container with ID = %s, name = %s and image name = %s", container.ID, container.Name, container.Image.Name)
+	} else {
+		log.Debug("successfully removed container with ID = %s, name = %s and image name = %s", container.ID, container.Name, container.Image.Name)
+	}
 }

--- a/containerm/deployment/deployment_internal_init.go
+++ b/containerm/deployment/deployment_internal_init.go
@@ -33,7 +33,7 @@ func registryInit(registryCtx *registry.ServiceRegistryContext) (interface{}, er
 	return newDeploymentMgr(options.mode, options.metaPath, options.ctrPath, mgrService.(mgr.ContainerManager))
 }
 
-func newDeploymentMgr(mode, metaPath, ctrPath string, ctrMgr mgr.ContainerManager) (Manager, error) {
+func newDeploymentMgr(mode Mode, metaPath, ctrPath string, ctrMgr mgr.ContainerManager) (Manager, error) {
 	if err := util.MkDir(metaPath); err != nil {
 		return nil, err
 	}

--- a/containerm/deployment/deployment_internal_init.go
+++ b/containerm/deployment/deployment_internal_init.go
@@ -30,17 +30,18 @@ func registryInit(registryCtx *registry.ServiceRegistryContext) (interface{}, er
 	}
 
 	//initialize the deployment manager local service
-	return newDeploymentMgr(options.metaPath, options.initialDeployPath, mgrService.(mgr.ContainerManager))
+	return newDeploymentMgr(options.mode, options.metaPath, options.ctrPath, mgrService.(mgr.ContainerManager))
 }
 
-func newDeploymentMgr(metaPath, initialDeployPath string, ctrMgr mgr.ContainerManager) (Manager, error) {
+func newDeploymentMgr(mode, metaPath, ctrPath string, ctrMgr mgr.ContainerManager) (Manager, error) {
 	if err := util.MkDir(metaPath); err != nil {
 		return nil, err
 	}
 
 	return &deploymentMgr{
-		metaPath:          metaPath,
-		initialDeployPath: initialDeployPath,
-		ctrMgr:            ctrMgr,
+		mode:     mode,
+		metaPath: metaPath,
+		ctrPath:  ctrPath,
+		ctrMgr:   ctrMgr,
 	}, nil
 }

--- a/containerm/deployment/deployment_opts.go
+++ b/containerm/deployment/deployment_opts.go
@@ -12,11 +12,13 @@
 
 package deployment
 
+import "github.com/eclipse-kanto/container-management/containerm/log"
+
 // Opt provides deployment manager options
 type Opt func(options *opts) error
 
 type opts struct {
-	mode     string
+	mode     Mode
 	metaPath string
 	ctrPath  string
 }
@@ -49,7 +51,19 @@ func WithCtrPath(ctrPath string) Opt {
 // WithMode sets the mode of deployment service
 func WithMode(mode string) Opt {
 	return func(dOpts *opts) error {
-		dOpts.mode = mode
+		dOpts.mode = toDeploymentMode(mode)
 		return nil
 	}
+}
+
+func toDeploymentMode(mode string) Mode {
+	switch mode {
+	case string(InitialDeployMode):
+		return InitialDeployMode
+	case string(UpdateMode):
+		return UpdateMode
+	}
+	defValue := UpdateMode
+	log.Warn("Invalid value '%s' for deployment mode option, switching to default mode %s", mode, defValue)
+	return defValue
 }

--- a/containerm/deployment/deployment_opts.go
+++ b/containerm/deployment/deployment_opts.go
@@ -16,8 +16,9 @@ package deployment
 type Opt func(options *opts) error
 
 type opts struct {
-	metaPath          string
-	initialDeployPath string
+	mode     string
+	metaPath string
+	ctrPath  string
 }
 
 func applyOpts(options *opts, opts ...Opt) error {
@@ -37,10 +38,18 @@ func WithMetaPath(metaPath string) Opt {
 	}
 }
 
-// WithInitialDeployPath sets container initial deployment path.
-func WithInitialDeployPath(initialDeployPath string) Opt {
+// WithCtrPath sets the path to container descriptors
+func WithCtrPath(ctrPath string) Opt {
 	return func(dOpts *opts) error {
-		dOpts.initialDeployPath = initialDeployPath
+		dOpts.ctrPath = ctrPath
+		return nil
+	}
+}
+
+// WithMode sets the mode of deployment service
+func WithMode(mode string) Opt {
+	return func(dOpts *opts) error {
+		dOpts.mode = mode
 		return nil
 	}
 }

--- a/containerm/deployment/deployment_opts_test.go
+++ b/containerm/deployment/deployment_opts_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/eclipse-kanto/container-management/containerm/pkg/testutil"
 )
 
-const testMode = ModeInitialDeploy
+const testMode = InitialDeployMode
 const testMetaPath = "testMetaPath"
 const testCtrPath = "testCtrPath"
 
@@ -30,7 +30,7 @@ func TestApplyDeploymentOpts(t *testing.T) {
 	}{
 		"test_apply_without_error": {
 			testOpts: []Opt{
-				WithMode(testMode),
+				WithMode(string(testMode)),
 				WithMetaPath(testMetaPath),
 				WithCtrPath(testCtrPath),
 			},
@@ -60,7 +60,7 @@ func TestDeploymentOpts(t *testing.T) {
 		expectedOpts *opts
 	}{
 		"test_deployment_mode": {
-			testOpt: WithMode(testMode),
+			testOpt: WithMode(string(testMode)),
 			expectedOpts: &opts{
 				mode: testMode,
 			},

--- a/containerm/deployment/deployment_opts_test.go
+++ b/containerm/deployment/deployment_opts_test.go
@@ -19,8 +19,9 @@ import (
 	"github.com/eclipse-kanto/container-management/containerm/pkg/testutil"
 )
 
+const testMode = ModeInitialDeploy
 const testMetaPath = "testMetaPath"
-const testInitialDeployPath = "testInitialDeployPath"
+const testCtrPath = "testCtrPath"
 
 func TestApplyDeploymentOpts(t *testing.T) {
 	tests := map[string]struct {
@@ -29,8 +30,9 @@ func TestApplyDeploymentOpts(t *testing.T) {
 	}{
 		"test_apply_without_error": {
 			testOpts: []Opt{
+				WithMode(testMode),
 				WithMetaPath(testMetaPath),
-				WithInitialDeployPath(testInitialDeployPath),
+				WithCtrPath(testCtrPath),
 			},
 		},
 		"test_apply_with_error": {
@@ -57,6 +59,12 @@ func TestDeploymentOpts(t *testing.T) {
 		testOpt      Opt
 		expectedOpts *opts
 	}{
+		"test_deployment_mode": {
+			testOpt: WithMode(testMode),
+			expectedOpts: &opts{
+				mode: testMode,
+			},
+		},
 		"test_deployment_meta_path": {
 			testOpt: WithMetaPath(testMetaPath),
 			expectedOpts: &opts{
@@ -64,9 +72,9 @@ func TestDeploymentOpts(t *testing.T) {
 			},
 		},
 		"test_deployment_initial_deploy_path": {
-			testOpt: WithInitialDeployPath(testInitialDeployPath),
+			testOpt: WithCtrPath(testCtrPath),
 			expectedOpts: &opts{
-				initialDeployPath: testInitialDeployPath,
+				ctrPath: testCtrPath,
 			},
 		},
 	}

--- a/containerm/deployment/deployment_test.go
+++ b/containerm/deployment/deployment_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/eclipse-kanto/container-management/containerm/containers/types"
 	"github.com/eclipse-kanto/container-management/containerm/log"
 	"github.com/eclipse-kanto/container-management/containerm/pkg/testutil"
-	"github.com/eclipse-kanto/container-management/containerm/pkg/testutil/mocks/mgr"
+	mocks "github.com/eclipse-kanto/container-management/containerm/pkg/testutil/mocks/mgr"
 	"github.com/eclipse-kanto/container-management/containerm/util"
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
@@ -50,13 +50,11 @@ func TestInitialDeploy(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		mode     string
 		metaPath string
 		ctrPath  string
 		mockExec func(*mocks.MockContainerManager) error
 	}{
 		"test_initial_deploy_containers_not_a_first_run": {
-			mode: ModeInitialDeploy,
 			metaPath: func() string {
 				path := createTmpMetaPath(t)
 				err := util.MkDir(filepath.Join(path, "deployment"))
@@ -68,7 +66,6 @@ func TestInitialDeploy(t *testing.T) {
 			},
 		},
 		"test_initial_deploy_containers_exist": {
-			mode:     ModeInitialDeploy,
 			metaPath: createTmpMetaPath(t),
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
 				mockMgr.EXPECT().List(testContext).Return([]*types.Container{{}}, nil)
@@ -76,7 +73,6 @@ func TestInitialDeploy(t *testing.T) {
 			},
 		},
 		"test_initial_deploy_containers_list_error": {
-			mode:     ModeInitialDeploy,
 			metaPath: createTmpMetaPath(t),
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
 				err := log.NewError("test error")
@@ -85,16 +81,14 @@ func TestInitialDeploy(t *testing.T) {
 			},
 		},
 		"test_initial_deploy_path_is_file_error": {
-			mode:     ModeInitialDeploy,
 			metaPath: createTmpMetaPath(t),
 			ctrPath:  validCtrJSONPath,
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
 				mockMgr.EXPECT().List(testContext).Return(nil, nil)
-				return log.NewErrorf("the initial containers deploy path = %s is not a directory", validCtrJSONPath)
+				return log.NewErrorf("the containers deploy path = %s is not a directory", validCtrJSONPath)
 			},
 		},
 		"test_initial_deploy_path_not_exist": {
-			mode:     ModeInitialDeploy,
 			metaPath: createTmpMetaPath(t),
 			ctrPath:  filepath.Join(baseCtrJSONPath, "not/exist"),
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
@@ -103,7 +97,6 @@ func TestInitialDeploy(t *testing.T) {
 			},
 		},
 		"test_initial_deploy_path_is_empty": {
-			mode:     ModeInitialDeploy,
 			metaPath: createTmpMetaPath(t),
 			ctrPath:  filepath.Join(baseCtrJSONPath, "empty"),
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
@@ -112,7 +105,6 @@ func TestInitialDeploy(t *testing.T) {
 			},
 		},
 		"test_initial_deploy_container_create_error": {
-			mode:     ModeInitialDeploy,
 			metaPath: createTmpMetaPath(t),
 			ctrPath:  filepath.Join(baseCtrJSONPath, "nested"),
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
@@ -127,7 +119,6 @@ func TestInitialDeploy(t *testing.T) {
 			},
 		},
 		"test_initial_deploy_container_start_error": {
-			mode:     ModeInitialDeploy,
 			metaPath: createTmpMetaPath(t),
 			ctrPath:  filepath.Join(baseCtrJSONPath, "nested"),
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
@@ -146,7 +137,6 @@ func TestInitialDeploy(t *testing.T) {
 			},
 		},
 		"test_initial_deploy_multiple_containers": {
-			mode:     ModeInitialDeploy,
 			metaPath: createTmpMetaPath(t),
 			ctrPath:  baseCtrJSONPath,
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
@@ -192,14 +182,14 @@ func TestInitialDeploy(t *testing.T) {
 			mockMgr := mocks.NewMockContainerManager(mockCtrl)
 
 			deployMgr := &deploymentMgr{
-				mode:     testCase.mode,
+				mode:     ModeInitialDeploy,
 				metaPath: testCase.metaPath,
 				ctrPath:  testCase.ctrPath,
 				ctrMgr:   mockMgr,
 			}
 
 			expectedErr := testCase.mockExec(mockMgr)
-			actualErr := deployMgr.InitialDeploy(testContext)
+			actualErr := deployMgr.Deploy(testContext)
 			testutil.AssertError(t, expectedErr, actualErr)
 			testutil.AssertWithTimeout(t, testWaitGroup, testTimeoutDuration)
 		})

--- a/containerm/deployment/deployment_test.go
+++ b/containerm/deployment/deployment_test.go
@@ -99,7 +99,7 @@ func TestDeployCommon(t *testing.T) {
 			mockMgr := mocks.NewMockContainerManager(mockCtrl)
 
 			deployMgr := &deploymentMgr{
-				mode:     ModeInitialDeploy,
+				mode:     InitialDeployMode,
 				metaPath: metaPath,
 				ctrPath:  testCase.ctrPath,
 				ctrMgr:   mockMgr,
@@ -108,7 +108,7 @@ func TestDeployCommon(t *testing.T) {
 			actualErr := deployMgr.Deploy(testContext)
 			testutil.AssertError(t, expectedErr, actualErr)
 
-			deployMgr.mode = ModeUpdate
+			deployMgr.mode = UpdateMode
 			actualErr = deployMgr.Deploy(testContext)
 			testutil.AssertError(t, expectedErr, actualErr)
 		})
@@ -217,7 +217,7 @@ func TestInitialDeploy(t *testing.T) {
 			mockMgr := mocks.NewMockContainerManager(mockCtrl)
 
 			deployMgr := &deploymentMgr{
-				mode:     ModeInitialDeploy,
+				mode:     InitialDeployMode,
 				metaPath: testCase.metaPath,
 				ctrPath:  testCase.ctrPath,
 				ctrMgr:   mockMgr,
@@ -538,7 +538,7 @@ func TestUpdate(t *testing.T) {
 			mockMgr := mocks.NewMockContainerManager(mockCtrl)
 
 			deployMgr := &deploymentMgr{
-				mode:     ModeUpdate,
+				mode:     UpdateMode,
 				metaPath: metaPath,
 				ctrPath:  testCase.ctrPath,
 				ctrMgr:   mockMgr,

--- a/containerm/deployment/deployment_test.go
+++ b/containerm/deployment/deployment_test.go
@@ -50,11 +50,13 @@ func TestInitialDeploy(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		metaPath          string
-		initialDeployPath string
-		mockExec          func(*mocks.MockContainerManager) error
+		mode     string
+		metaPath string
+		ctrPath  string
+		mockExec func(*mocks.MockContainerManager) error
 	}{
 		"test_initial_deploy_containers_not_a_first_run": {
+			mode: ModeInitialDeploy,
 			metaPath: func() string {
 				path := createTmpMetaPath(t)
 				err := util.MkDir(filepath.Join(path, "deployment"))
@@ -66,6 +68,7 @@ func TestInitialDeploy(t *testing.T) {
 			},
 		},
 		"test_initial_deploy_containers_exist": {
+			mode:     ModeInitialDeploy,
 			metaPath: createTmpMetaPath(t),
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
 				mockMgr.EXPECT().List(testContext).Return([]*types.Container{{}}, nil)
@@ -73,6 +76,7 @@ func TestInitialDeploy(t *testing.T) {
 			},
 		},
 		"test_initial_deploy_containers_list_error": {
+			mode:     ModeInitialDeploy,
 			metaPath: createTmpMetaPath(t),
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
 				err := log.NewError("test error")
@@ -81,32 +85,36 @@ func TestInitialDeploy(t *testing.T) {
 			},
 		},
 		"test_initial_deploy_path_is_file_error": {
-			metaPath:          createTmpMetaPath(t),
-			initialDeployPath: validCtrJSONPath,
+			mode:     ModeInitialDeploy,
+			metaPath: createTmpMetaPath(t),
+			ctrPath:  validCtrJSONPath,
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
 				mockMgr.EXPECT().List(testContext).Return(nil, nil)
 				return log.NewErrorf("the initial containers deploy path = %s is not a directory", validCtrJSONPath)
 			},
 		},
 		"test_initial_deploy_path_not_exist": {
-			metaPath:          createTmpMetaPath(t),
-			initialDeployPath: filepath.Join(baseCtrJSONPath, "not/exist"),
+			mode:     ModeInitialDeploy,
+			metaPath: createTmpMetaPath(t),
+			ctrPath:  filepath.Join(baseCtrJSONPath, "not/exist"),
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
 				mockMgr.EXPECT().List(testContext).Return(nil, nil)
 				return nil
 			},
 		},
 		"test_initial_deploy_path_is_empty": {
-			metaPath:          createTmpMetaPath(t),
-			initialDeployPath: filepath.Join(baseCtrJSONPath, "empty"),
+			mode:     ModeInitialDeploy,
+			metaPath: createTmpMetaPath(t),
+			ctrPath:  filepath.Join(baseCtrJSONPath, "empty"),
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
 				mockMgr.EXPECT().List(testContext).Return(nil, nil)
 				return nil
 			},
 		},
 		"test_initial_deploy_container_create_error": {
-			metaPath:          createTmpMetaPath(t),
-			initialDeployPath: filepath.Join(baseCtrJSONPath, "nested"),
+			mode:     ModeInitialDeploy,
+			metaPath: createTmpMetaPath(t),
+			ctrPath:  filepath.Join(baseCtrJSONPath, "nested"),
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
 				testWaitGroup.Add(1)
 				mockMgr.EXPECT().List(testContext).Return(nil, nil)
@@ -119,8 +127,9 @@ func TestInitialDeploy(t *testing.T) {
 			},
 		},
 		"test_initial_deploy_container_start_error": {
-			metaPath:          createTmpMetaPath(t),
-			initialDeployPath: filepath.Join(baseCtrJSONPath, "nested"),
+			mode:     ModeInitialDeploy,
+			metaPath: createTmpMetaPath(t),
+			ctrPath:  filepath.Join(baseCtrJSONPath, "nested"),
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
 				testWaitGroup.Add(1)
 				mockMgr.EXPECT().List(testContext).Return(nil, nil)
@@ -137,8 +146,9 @@ func TestInitialDeploy(t *testing.T) {
 			},
 		},
 		"test_initial_deploy_multiple_containers": {
-			metaPath:          createTmpMetaPath(t),
-			initialDeployPath: baseCtrJSONPath,
+			mode:     ModeInitialDeploy,
+			metaPath: createTmpMetaPath(t),
+			ctrPath:  baseCtrJSONPath,
 			mockExec: func(mockMgr *mocks.MockContainerManager) error {
 				testWaitGroup.Add(1)
 				mockMgr.EXPECT().List(testContext).Return(nil, nil)
@@ -182,9 +192,10 @@ func TestInitialDeploy(t *testing.T) {
 			mockMgr := mocks.NewMockContainerManager(mockCtrl)
 
 			deployMgr := &deploymentMgr{
-				metaPath:          testCase.metaPath,
-				initialDeployPath: testCase.initialDeployPath,
-				ctrMgr:            mockMgr,
+				mode:     testCase.mode,
+				metaPath: testCase.metaPath,
+				ctrPath:  testCase.ctrPath,
+				ctrMgr:   mockMgr,
 			}
 
 			expectedErr := testCase.mockExec(mockMgr)

--- a/containerm/pkg/testutil/config/container/nested/container-config.json
+++ b/containerm/pkg/testutil/config/container/nested/container-config.json
@@ -1,4 +1,5 @@
 {
+  "container_name": "redis",
   "image": {
     "name": "docker.io/library/redis:latest"
   }

--- a/containerm/pkg/testutil/config/container/valid.json
+++ b/containerm/pkg/testutil/config/container/valid.json
@@ -1,4 +1,5 @@
 {
+  "container_name": "influxdb",
   "image": {
     "name": "docker.io/library/influxdb:latest"
   }

--- a/containerm/pkg/testutil/config/daemon-config.json
+++ b/containerm/pkg/testutil/config/daemon-config.json
@@ -65,7 +65,9 @@
     }
   },
   "deployment": {
+    "enable": true,
+    "mode": "update",
     "home_dir": "/var/lib/container-management",
-    "init_dir": "/etc/container-management/containers"
+    "ctr_dir": "/etc/container-management/containers"
   }
 }

--- a/containerm/pkg/testutil/matchers/container_image_matcher.go
+++ b/containerm/pkg/testutil/matchers/container_image_matcher.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package matchers
+
+import (
+	"fmt"
+
+	"github.com/eclipse-kanto/container-management/containerm/containers/types"
+	"github.com/golang/mock/gomock"
+)
+
+type containerImageMatcher struct {
+	containerName  string
+	containerImage string
+}
+
+// MatchesContainerImage returns a Matcher interface for the Container's name and image name
+func MatchesContainerImage(name, image string) gomock.Matcher {
+	return &containerImageMatcher{containerName: name, containerImage: image}
+}
+
+func (o *containerImageMatcher) Matches(x interface{}) bool {
+	switch c := x.(type) {
+	case *types.Container:
+		return c.Name == o.containerName && c.Image.Name == o.containerImage
+	case types.Container:
+		return c.Name == o.containerName && c.Image.Name == o.containerImage
+	default:
+		return false
+	}
+}
+
+func (o *containerImageMatcher) String() string {
+	return fmt.Sprintf("container name is not %s or image name is not %+s", o.containerName, o.containerImage)
+}

--- a/containerm/util/containers.go
+++ b/containerm/util/containers.go
@@ -497,3 +497,14 @@ func ReadContainer(path string) (*types.Container, error) {
 	}
 	return ctr, nil
 }
+
+// AsNamedMap returns a map of containers where key is the container's name
+func AsNamedMap(containersList []*types.Container) map[string]*types.Container {
+	result := map[string]*types.Container{}
+	for _, container := range containersList {
+		if container != nil {
+			result[container.Name] = container
+		}
+	}
+	return result
+}

--- a/containerm/util/containers_compare.go
+++ b/containerm/util/containers_compare.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package util
+
+import (
+	"reflect"
+
+	"github.com/eclipse-kanto/container-management/containerm/containers/types"
+)
+
+// ActionType defines a type for an action to achieve desired container
+type ActionType int
+
+const (
+	// ActionCheck denotes that current container already has the desired configuration, it shall be checked only if the container is running
+	ActionCheck ActionType = iota
+	// ActionCreate denotes that a new container with desired configurtion shall be created and started
+	ActionCreate
+	// ActionRecreate denotes that the existing container shall be replaced by a new container with desired configurtion
+	ActionRecreate
+	// ActionUpdate denotes that the existing container shall be runtime updated with desired configurtion
+	ActionUpdate
+	// ActionDestroy denotes that the existing container shall be destroyed
+	ActionDestroy
+)
+
+// DetermineUpdateAction compares the current container with the desired one and determines what action shall be done to achieve desired state
+func DetermineUpdateAction(current *types.Container, desired *types.Container) ActionType {
+	if current == nil {
+		return ActionCreate
+	}
+	if !isEqualImage(current.Image, desired.Image) {
+		return ActionRecreate
+	}
+	if !compareSliceObjects(current.Mounts, desired.Mounts) {
+		return ActionRecreate
+	}
+	if !isEqualContainerConfig(current.Config, desired.Config) {
+		return ActionRecreate
+	}
+	if !isEqualIOConfig(current.IOConfig, desired.IOConfig) {
+		return ActionRecreate
+	}
+	if !isEqualHostConfig0(current.HostConfig, desired.HostConfig) {
+		return ActionRecreate
+	}
+	if !isEqualHostConfig1(current.HostConfig, desired.HostConfig) {
+		return ActionUpdate
+	}
+	return ActionCheck
+}
+
+func isEqualImage(currentImage types.Image, newImage types.Image) bool {
+	return currentImage.Name == newImage.Name
+}
+
+func isEqualContainerConfig(currentContainerCfg *types.ContainerConfiguration, newContainerCfg *types.ContainerConfiguration) bool {
+	if currentContainerCfg == nil {
+		return newContainerCfg == nil
+	}
+	if newContainerCfg == nil {
+		return false
+	}
+	if !(len(currentContainerCfg.Cmd) == 0 && len(newContainerCfg.Cmd) == 0) && !reflect.DeepEqual(currentContainerCfg.Cmd, newContainerCfg.Cmd) {
+		return false
+	}
+
+	return compareSliceObjects(currentContainerCfg.Env, newContainerCfg.Env)
+}
+
+func isEqualHostConfig0(currentHostConfig *types.HostConfig, newHostConfig *types.HostConfig) bool {
+	if currentHostConfig == nil {
+		return newHostConfig == nil
+	}
+	if newHostConfig == nil {
+		return false
+	}
+	if currentHostConfig.Privileged != newHostConfig.Privileged {
+		return false
+	}
+	if currentHostConfig.NetworkMode != newHostConfig.NetworkMode {
+		return false
+	}
+	if !compareSliceObjects(currentHostConfig.Devices, newHostConfig.Devices) {
+		return false
+	}
+	if !compareSliceObjects(currentHostConfig.ExtraHosts, newHostConfig.ExtraHosts) {
+		return false
+	}
+	if !compareSliceObjects(currentHostConfig.PortMappings, newHostConfig.PortMappings) {
+		return false
+	}
+	if !isEqualLog(currentHostConfig.LogConfig, newHostConfig.LogConfig) {
+		return false
+	}
+
+	return true
+}
+
+func isEqualHostConfig1(currentHostConfig *types.HostConfig, newHostConfig *types.HostConfig) bool {
+	if currentHostConfig == nil {
+		return newHostConfig == nil
+	}
+	if !isEqualResources(currentHostConfig.Resources, newHostConfig.Resources) {
+		return false
+	}
+	if !isEqualRestartPolicy(currentHostConfig.RestartPolicy, newHostConfig.RestartPolicy) {
+		return false
+	}
+	return true
+}
+
+func isEqualResources(currentResources *types.Resources, newResources *types.Resources) bool {
+	if currentResources == nil {
+		return newResources == nil
+	}
+	if newResources == nil {
+		return false
+	}
+	return *currentResources == *newResources
+}
+
+func isEqualRestartPolicy(currentRestartPolicy *types.RestartPolicy, newRestartPolicy *types.RestartPolicy) bool {
+	if currentRestartPolicy == nil {
+		return newRestartPolicy == nil
+	}
+	if newRestartPolicy == nil {
+		return false
+	}
+	return *currentRestartPolicy == *newRestartPolicy
+}
+
+func isEqualLog(currentLogConfig *types.LogConfiguration, newLogConfig *types.LogConfiguration) bool {
+	if currentLogConfig == nil {
+		return newLogConfig == nil
+	}
+	if newLogConfig == nil {
+		return false
+	}
+	if currentLogConfig.DriverConfig == nil {
+		return newLogConfig.DriverConfig == nil
+	}
+	if newLogConfig.DriverConfig == nil {
+		return false
+	}
+	if *currentLogConfig.DriverConfig != *newLogConfig.DriverConfig {
+		return false
+	}
+	if currentLogConfig.ModeConfig == nil {
+		return newLogConfig.ModeConfig == nil
+	}
+	if newLogConfig.ModeConfig == nil {
+		return false
+	}
+	if *currentLogConfig.ModeConfig != *newLogConfig.ModeConfig {
+		return false
+	}
+	return true
+}
+
+func isEqualIOConfig(currentIOConfig *types.IOConfig, newIOConfig *types.IOConfig) bool {
+	if currentIOConfig == nil {
+		return newIOConfig == nil
+	}
+
+	if newIOConfig == nil {
+		return false
+	}
+	return currentIOConfig.OpenStdin == newIOConfig.OpenStdin && currentIOConfig.Tty == newIOConfig.Tty
+}
+
+func compareSliceObjects(firstObject interface{}, secondObject interface{}) bool {
+	firstValue := reflect.ValueOf(firstObject)
+	secondValue := reflect.ValueOf(secondObject)
+	if firstValue.Len() != secondValue.Len() {
+		return false
+	}
+	for firstIndex := 0; firstIndex < firstValue.Len(); firstIndex++ {
+		hasSameElement := false
+		firstSliceElement := firstValue.Index(firstIndex)
+		for secondIndex := 0; secondIndex < secondValue.Len(); secondIndex++ {
+			secondSliceElement := secondValue.Index(secondIndex)
+			if firstSliceElement.Interface() == secondSliceElement.Interface() {
+				hasSameElement = true
+			}
+		}
+		if !hasSameElement {
+			return false
+		}
+	}
+	for secondIndex := 0; secondIndex < secondValue.Len(); secondIndex++ {
+		hasSameElement := false
+		secondSliceElement := secondValue.Index(secondIndex)
+		for firstIndex := 0; firstIndex < firstValue.Len(); firstIndex++ {
+			firstSliceElement := firstValue.Index(firstIndex)
+
+			if firstSliceElement.Interface() == secondSliceElement.Interface() {
+				hasSameElement = true
+			}
+		}
+		if !hasSameElement {
+			return false
+		}
+	}
+	return true
+}

--- a/containerm/util/containers_compare_test.go
+++ b/containerm/util/containers_compare_test.go
@@ -1005,3 +1005,43 @@ func TestIsEqualIOConfig(t *testing.T) {
 		testutil.AssertEqual(t, testCase.expectedResult, res)
 	}
 }
+
+func TestCompareSliceSet(t *testing.T) {
+	testCases := map[string]struct {
+		slice1 interface{}
+		slice2 interface{}
+		match  bool
+	}{
+		"test_equal_same_order": {
+			slice1: []string{"a", "b", "c"},
+			slice2: []string{"a", "b", "c"},
+			match:  true,
+		},
+		"test_equal_mixed_order": {
+			slice1: []string{"a", "b", "c"},
+			slice2: []string{"b", "a", "c"},
+			match:  true,
+		},
+		"test_equal_duplicates": {
+			slice1: []string{"x", "x", "y"},
+			slice2: []string{"y", "x", "x"},
+			match:  true,
+		},
+		"test_equal_duplicates_diff_count": {
+			slice1: []string{"x", "x", "y"},
+			slice2: []string{"y", "y", "x"},
+			match:  true,
+		},
+		"test_unequal": {
+			slice1: []string{"x", "x", "y"},
+			slice2: []string{"x", "y", "z"},
+			match:  false,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Log(testName)
+		testutil.AssertEqual(t, testCase.match, compareSliceSet(testCase.slice1, testCase.slice2))
+		testutil.AssertEqual(t, testCase.match, compareSliceSet(testCase.slice2, testCase.slice1))
+	}
+}

--- a/containerm/util/containers_compare_test.go
+++ b/containerm/util/containers_compare_test.go
@@ -1,0 +1,1007 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package util
+
+import (
+	"testing"
+
+	"github.com/eclipse-kanto/container-management/containerm/containers/types"
+	"github.com/eclipse-kanto/container-management/containerm/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetermineUpdateAction(t *testing.T) {
+	testCases := map[string]struct {
+		current        *types.Container
+		desired        *types.Container
+		expectedResult ActionType
+	}{
+		"test_current_nil": {
+			current:        nil,
+			desired:        nil,
+			expectedResult: ActionCreate,
+		},
+		"test_image_name_equal": {
+			current: &types.Container{
+				Image: types.Image{Name: "name1"},
+			},
+			desired: &types.Container{
+				Image: types.Image{Name: "name1"},
+			},
+			expectedResult: ActionCheck,
+		},
+		"test_image_name_not_equal": {
+			current: &types.Container{
+				Image: types.Image{Name: "name1"},
+			},
+			desired: &types.Container{
+				Image: types.Image{Name: "name2"},
+			},
+			expectedResult: ActionRecreate,
+		},
+		"test_mounts_equal": {
+			current: &types.Container{
+				Mounts: []types.MountPoint{
+					{Destination: "testDestination2", Source: "testSource2", PropagationMode: "private"},
+					{Destination: "testDestination1", Source: "testSource1", PropagationMode: "private"},
+				},
+			},
+			desired: &types.Container{
+				Mounts: []types.MountPoint{
+					{Destination: "testDestination1", Source: "testSource1", PropagationMode: "private"},
+					{Destination: "testDestination2", Source: "testSource2", PropagationMode: "private"},
+				},
+			},
+			expectedResult: ActionCheck,
+		},
+		"test_mounts_not_equal": {
+			current: &types.Container{
+				Mounts: []types.MountPoint{
+					{Destination: "testDestination", Source: "testSource", PropagationMode: "private"},
+					{Destination: "testDestination", Source: "testSource", PropagationMode: "private"},
+				},
+			},
+			desired: &types.Container{
+				Mounts: []types.MountPoint{
+					{Destination: "testDestination", Source: "testSource", PropagationMode: "private"},
+					{Destination: "testDestination", Source: "notequal", PropagationMode: "private"},
+				},
+			},
+			expectedResult: ActionRecreate,
+		},
+		"test_container_config_equal": {
+			current: &types.Container{
+				Config: &types.ContainerConfiguration{Env: []string{"testEnv"}, Cmd: []string{"testCmd"}},
+			},
+			desired: &types.Container{
+				Config: &types.ContainerConfiguration{Env: []string{"testEnv"}, Cmd: []string{"testCmd"}},
+			},
+			expectedResult: ActionCheck,
+		},
+		"test_container_config_cmd_empty_and_nil_not_equal": {
+			current: &types.Container{
+				Config: &types.ContainerConfiguration{Env: []string{"testEnv"}, Cmd: []string{}},
+			},
+			desired: &types.Container{
+				Config: &types.ContainerConfiguration{Env: []string{"testEnv"}},
+			},
+			expectedResult: ActionCheck,
+		},
+		"test_container_config_cmd_elements_empty_not_equal": {
+			current: &types.Container{
+				Config: &types.ContainerConfiguration{Env: []string{"testEnv"}, Cmd: []string{}},
+			},
+			desired: &types.Container{
+				Config: &types.ContainerConfiguration{Env: []string{"testEnv"}, Cmd: []string{}},
+			},
+			expectedResult: ActionCheck,
+		},
+		"test_container_config_cmd_elements_nil_not_equal": {
+			current: &types.Container{
+				Config: &types.ContainerConfiguration{Env: []string{"testEnv"}},
+			},
+			desired: &types.Container{
+				Config: &types.ContainerConfiguration{Env: []string{"testEnv"}},
+			},
+			expectedResult: ActionCheck,
+		},
+		"test_container_config_cmd_one_empty_element_and_one_not_empty_not_equal": {
+			current: &types.Container{
+				Config: &types.ContainerConfiguration{Env: []string{"testEnv"}, Cmd: []string{"testCmd"}},
+			},
+			desired: &types.Container{
+				Config: &types.ContainerConfiguration{Env: []string{"testEnv"}, Cmd: []string{}},
+			},
+			expectedResult: ActionRecreate,
+		},
+		"test_container_config_not_equal": {
+			current: &types.Container{
+				Config: &types.ContainerConfiguration{Env: []string{"testEnv1", "testEnv2"}, Cmd: []string{"testCmd1", "testCmd2"}},
+			},
+			desired: &types.Container{
+				Config: &types.ContainerConfiguration{Env: []string{"testEnv1", "notequal"}, Cmd: []string{"testCmd1", "testCmd2"}},
+			},
+			expectedResult: ActionRecreate,
+		},
+		"test_ioconfig_equal": {
+			current: &types.Container{
+				IOConfig: &types.IOConfig{
+					AttachStderr: true,
+					AttachStdin:  true,
+					AttachStdout: true,
+					OpenStdin:    true,
+					StdinOnce:    true,
+					Tty:          true,
+				},
+			},
+			desired: &types.Container{
+				IOConfig: &types.IOConfig{
+					AttachStderr: true,
+					AttachStdin:  true,
+					AttachStdout: true,
+					OpenStdin:    true,
+					StdinOnce:    true,
+					Tty:          true,
+				},
+			},
+			expectedResult: ActionCheck,
+		},
+		"test_ioconfig_not_equal": {
+			current: &types.Container{
+				IOConfig: &types.IOConfig{
+					AttachStderr: true,
+					AttachStdin:  true,
+					AttachStdout: true,
+					OpenStdin:    false,
+					StdinOnce:    true,
+					Tty:          true,
+				},
+			},
+			desired: &types.Container{
+				IOConfig: &types.IOConfig{
+					AttachStderr: true,
+					AttachStdin:  true,
+					AttachStdout: true,
+					OpenStdin:    true,
+					StdinOnce:    true,
+					Tty:          true,
+				},
+			},
+			expectedResult: ActionRecreate,
+		},
+		"test_hostconfig0_equal": {
+			current: &types.Container{
+				HostConfig: &types.HostConfig{
+					Privileged: true,
+				},
+			},
+			desired: &types.Container{
+				HostConfig: &types.HostConfig{
+					Privileged: true,
+				},
+			},
+			expectedResult: ActionCheck,
+		},
+		"test_hostconfig0_not_equal": {
+			current: &types.Container{
+				HostConfig: &types.HostConfig{
+					Privileged: true,
+				},
+			},
+			desired: &types.Container{
+				HostConfig: &types.HostConfig{
+					Privileged: false,
+				},
+			},
+			expectedResult: ActionRecreate,
+		},
+		"test_hostconfig1_equal": {
+			current: &types.Container{
+				HostConfig: &types.HostConfig{
+					RestartPolicy: &types.RestartPolicy{
+						MaximumRetryCount: 0,
+						RetryTimeout:      0,
+						Type:              "always",
+					},
+					Resources: &types.Resources{
+						Memory:            "4m",
+						MemoryReservation: "3m",
+						MemorySwap:        "-1",
+					},
+				},
+			},
+			desired: &types.Container{
+				HostConfig: &types.HostConfig{
+					RestartPolicy: &types.RestartPolicy{
+						MaximumRetryCount: 0,
+						RetryTimeout:      0,
+						Type:              "always",
+					},
+					Resources: &types.Resources{
+						Memory:            "4m",
+						MemoryReservation: "3m",
+						MemorySwap:        "-1",
+					},
+				},
+			},
+			expectedResult: ActionCheck,
+		},
+		"test_hostconfig1_not_equal": {
+			current: &types.Container{
+				HostConfig: &types.HostConfig{
+					RestartPolicy: &types.RestartPolicy{
+						MaximumRetryCount: 0,
+						RetryTimeout:      0,
+						Type:              "always",
+					},
+					Resources: &types.Resources{
+						Memory:            "4m",
+						MemoryReservation: "3m",
+						MemorySwap:        "-1",
+					},
+				},
+			},
+			desired: &types.Container{
+				HostConfig: &types.HostConfig{
+					RestartPolicy: &types.RestartPolicy{
+						MaximumRetryCount: 0,
+						RetryTimeout:      0,
+						Type:              "always",
+					},
+					Resources: &types.Resources{
+						Memory:            "4m",
+						MemoryReservation: "34m",
+						MemorySwap:        "-1",
+					},
+				},
+			},
+			expectedResult: ActionUpdate,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Log(testName)
+
+		res := DetermineUpdateAction(testCase.current, testCase.desired)
+		testutil.AssertEqual(t, testCase.expectedResult, res)
+	}
+}
+
+func TestIsEqualImage(t *testing.T) {
+	t.Run("test_image_equal", func(t *testing.T) {
+		current := types.Image{Name: "name"}
+		desired := types.Image{Name: "name"}
+
+		res := isEqualImage(current, desired)
+
+		assert.True(t, res)
+	})
+
+	t.Run("test_image_not_equal", func(t *testing.T) {
+		current := types.Image{Name: "name1"}
+		desired := types.Image{Name: "name2"}
+
+		res := isEqualImage(current, desired)
+
+		assert.False(t, res)
+	})
+}
+
+func TestIsEqualContainerConfig(t *testing.T) {
+	testCases := map[string]struct {
+		current        *types.ContainerConfiguration
+		desired        *types.ContainerConfiguration
+		expectedResult bool
+	}{
+		"test_current_nil_desired_nil": {
+			current:        nil,
+			desired:        nil,
+			expectedResult: true,
+		},
+		"test_current_nil_desired_not_nil": {
+			current:        nil,
+			desired:        &types.ContainerConfiguration{},
+			expectedResult: false,
+		},
+		"test_current_not_nil_desired_nil": {
+			current:        &types.ContainerConfiguration{},
+			desired:        nil,
+			expectedResult: false,
+		},
+		"test_current_desired_equal": {
+			current:        &types.ContainerConfiguration{Env: []string{"testEnv"}, Cmd: []string{"testCmd"}},
+			desired:        &types.ContainerConfiguration{Env: []string{"testEnv"}, Cmd: []string{"testCmd"}},
+			expectedResult: true,
+		},
+		"test_env_not_equal": {
+			current:        &types.ContainerConfiguration{Env: []string{"testEnv"}, Cmd: []string{"testCmd"}},
+			desired:        &types.ContainerConfiguration{Env: []string{"testEnv2"}, Cmd: []string{"testCmd"}},
+			expectedResult: false,
+		},
+		"test_env_equal_ordering_not_equal": {
+			current:        &types.ContainerConfiguration{Env: []string{"testEnv", "testEnv2"}, Cmd: []string{"testCmd"}},
+			desired:        &types.ContainerConfiguration{Env: []string{"testEnv2", "testEnv"}, Cmd: []string{"testCmd"}},
+			expectedResult: true,
+		},
+		"test_cmd_not_equal": {
+			current:        &types.ContainerConfiguration{Env: []string{"testEnv"}, Cmd: []string{"testCmd"}},
+			desired:        &types.ContainerConfiguration{Env: []string{"testEnv"}, Cmd: []string{"testNotEqual"}},
+			expectedResult: false,
+		},
+		"test_cmd_equal_ordering_not_equal": {
+			current:        &types.ContainerConfiguration{Env: []string{"testEnv"}, Cmd: []string{"testCmd", "testCmd2"}},
+			desired:        &types.ContainerConfiguration{Env: []string{"testEnv"}, Cmd: []string{"testCmd2", "testCmd"}},
+			expectedResult: false,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Log(testName)
+
+		res := isEqualContainerConfig(testCase.current, testCase.desired)
+		testutil.AssertEqual(t, testCase.expectedResult, res)
+	}
+}
+
+func TestIsEqualHostConfig0(t *testing.T) {
+	testCases := map[string]struct {
+		current        *types.HostConfig
+		desired        *types.HostConfig
+		expectedResult bool
+	}{
+		"test_current_nil_desired_nil": {
+			current:        nil,
+			desired:        nil,
+			expectedResult: true,
+		},
+		"test_current_nil_desired_not_nil": {
+			current:        nil,
+			desired:        &types.HostConfig{},
+			expectedResult: false,
+		},
+		"test_current_not_nil_desired_nil": {
+			current:        &types.HostConfig{},
+			desired:        nil,
+			expectedResult: false,
+		},
+		"test_privileged_equal": {
+			current: &types.HostConfig{
+				Privileged: true,
+			},
+			desired: &types.HostConfig{
+				Privileged: true,
+			},
+			expectedResult: true,
+		},
+		"test_privileged_not_equal": {
+			current: &types.HostConfig{
+				Privileged: true,
+			},
+			desired: &types.HostConfig{
+				Privileged: false,
+			},
+			expectedResult: false,
+		},
+		"test_networkmode_equal": {
+			current: &types.HostConfig{
+				NetworkMode: "bridge",
+			},
+			desired: &types.HostConfig{
+				NetworkMode: "bridge",
+			},
+			expectedResult: true,
+		},
+		"test_networkmode_not_equal": {
+			current: &types.HostConfig{
+				NetworkMode: "bridge",
+			},
+			desired: &types.HostConfig{
+				NetworkMode: "host",
+			},
+			expectedResult: false,
+		},
+		"test_devices_equal": {
+			current: &types.HostConfig{
+				Devices: []types.DeviceMapping{
+					{PathOnHost: "test2PathOnHost", PathInContainer: "test2PathInContainer", CgroupPermissions: "rwm"},
+					{PathOnHost: "testPathOnHost", PathInContainer: "testPathInContainer", CgroupPermissions: "rwm"},
+				},
+			},
+			desired: &types.HostConfig{
+				Devices: []types.DeviceMapping{
+					{PathOnHost: "testPathOnHost", PathInContainer: "testPathInContainer", CgroupPermissions: "rwm"},
+					{PathOnHost: "test2PathOnHost", PathInContainer: "test2PathInContainer", CgroupPermissions: "rwm"},
+				},
+			},
+			expectedResult: true,
+		},
+		"test_devices_not_equal": {
+			current: &types.HostConfig{
+				Devices: []types.DeviceMapping{
+					{PathOnHost: "testPathOnHost", PathInContainer: "testPathInContainer", CgroupPermissions: "rwm"},
+					{PathOnHost: "test2PathOnHost", PathInContainer: "test2PathInContainer", CgroupPermissions: "rwm"},
+				},
+			},
+			desired: &types.HostConfig{
+				Devices: []types.DeviceMapping{
+					{PathOnHost: "notEqual", PathInContainer: "testPathInContainer", CgroupPermissions: "rwm"},
+				},
+			},
+			expectedResult: false,
+		},
+		"test_extrahosts_equal": {
+			current: &types.HostConfig{
+				ExtraHosts: []string{"testExtraHost", "testExtraHost2"},
+			},
+			desired: &types.HostConfig{
+				ExtraHosts: []string{"testExtraHost", "testExtraHost2"},
+			},
+			expectedResult: true,
+		},
+		"test_extrahosts_not_equal": {
+			current: &types.HostConfig{
+				ExtraHosts: []string{"testExtraHost", "testExtraHost2"},
+			},
+			desired: &types.HostConfig{
+				ExtraHosts: []string{"testExtraHost", "testExtraHostNotEqual"},
+			},
+			expectedResult: false,
+		},
+		"test_portmappings_equal": {
+			current: &types.HostConfig{
+				PortMappings: []types.PortMapping{
+					{
+						Proto:         "tcp",
+						ContainerPort: 80,
+						HostIP:        "0.0.0.0",
+						HostPort:      80,
+						HostPortEnd:   80,
+					},
+				}},
+			desired: &types.HostConfig{
+				PortMappings: []types.PortMapping{
+					{
+						Proto:         "tcp",
+						ContainerPort: 80,
+						HostIP:        "0.0.0.0",
+						HostPort:      80,
+						HostPortEnd:   80,
+					},
+				}},
+			expectedResult: true,
+		},
+		"test_portmappings_not_equal": {
+			current: &types.HostConfig{
+				PortMappings: []types.PortMapping{
+					{
+						Proto:         "tcp",
+						ContainerPort: 80,
+						HostIP:        "0.0.0.0",
+						HostPort:      80,
+						HostPortEnd:   80,
+					},
+				},
+			},
+			desired: &types.HostConfig{
+				PortMappings: []types.PortMapping{
+					{
+						Proto:         "tcp",
+						ContainerPort: 80,
+						HostIP:        "1.2.3.4",
+						HostPort:      80,
+						HostPortEnd:   80,
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		"test_logconfig_equal": {
+			current: &types.HostConfig{
+				LogConfig: &types.LogConfiguration{
+					DriverConfig: &types.LogDriverConfiguration{
+						Type:     "json-file",
+						MaxFiles: 1,
+						MaxSize:  "100M",
+						RootDir:  "testRootDir",
+					},
+					ModeConfig: &types.LogModeConfiguration{
+						Mode:          "non-blocking",
+						MaxBufferSize: "1m",
+					},
+				}},
+			desired: &types.HostConfig{
+				LogConfig: &types.LogConfiguration{
+					DriverConfig: &types.LogDriverConfiguration{
+						Type:     "json-file",
+						MaxFiles: 1,
+						MaxSize:  "100M",
+						RootDir:  "testRootDir",
+					},
+					ModeConfig: &types.LogModeConfiguration{
+						Mode:          "non-blocking",
+						MaxBufferSize: "1m",
+					},
+				}},
+			expectedResult: true,
+		},
+		"test_logconfig_not_equal": {
+			current: &types.HostConfig{
+				LogConfig: &types.LogConfiguration{
+					DriverConfig: &types.LogDriverConfiguration{
+						Type:     "json-file",
+						MaxFiles: 1,
+						MaxSize:  "100M",
+						RootDir:  "testRootDir",
+					},
+					ModeConfig: &types.LogModeConfiguration{
+						Mode:          "non-blocking",
+						MaxBufferSize: "1m",
+					},
+				}},
+			desired: &types.HostConfig{
+				LogConfig: &types.LogConfiguration{
+					DriverConfig: &types.LogDriverConfiguration{
+						Type:     "json-file",
+						MaxFiles: 1,
+					},
+				}},
+			expectedResult: false,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Log(testName)
+
+		res := isEqualHostConfig0(testCase.current, testCase.desired)
+		testutil.AssertEqual(t, testCase.expectedResult, res)
+	}
+}
+
+func TestIsEqualHostConfig1(t *testing.T) {
+	testCases := map[string]struct {
+		current        *types.HostConfig
+		desired        *types.HostConfig
+		expectedResult bool
+	}{
+		"test_resources_equal": {
+			current: &types.HostConfig{
+				Resources: &types.Resources{
+					Memory:            "4m",
+					MemoryReservation: "3m",
+					MemorySwap:        "-1",
+				},
+			},
+			desired: &types.HostConfig{
+				Resources: &types.Resources{
+					Memory:            "4m",
+					MemoryReservation: "3m",
+					MemorySwap:        "-1",
+				},
+			},
+			expectedResult: true,
+		},
+		"test_resources_not_equal": {
+			current: &types.HostConfig{
+				Resources: &types.Resources{
+					Memory:            "4m",
+					MemoryReservation: "3m",
+					MemorySwap:        "-1",
+				},
+			},
+			desired: &types.HostConfig{
+				Resources: &types.Resources{
+					Memory: "4m",
+				},
+			},
+			expectedResult: false,
+		},
+		"test_restartpolicy_equal": {
+			current: &types.HostConfig{
+				RestartPolicy: &types.RestartPolicy{
+					MaximumRetryCount: 0,
+					RetryTimeout:      0,
+					Type:              "always",
+				},
+			},
+			desired: &types.HostConfig{
+				RestartPolicy: &types.RestartPolicy{
+					MaximumRetryCount: 0,
+					RetryTimeout:      0,
+					Type:              "always",
+				},
+			},
+			expectedResult: true,
+		},
+		"test_restartpolicy_not_equal": {
+			current: &types.HostConfig{
+				RestartPolicy: &types.RestartPolicy{
+					MaximumRetryCount: 0,
+					RetryTimeout:      0,
+					Type:              "always",
+				},
+			},
+			desired: &types.HostConfig{
+				RestartPolicy: &types.RestartPolicy{
+					RetryTimeout: 5,
+					Type:         "always",
+				},
+			},
+			expectedResult: false,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Log(testName)
+
+		res := isEqualHostConfig1(testCase.current, testCase.desired)
+		testutil.AssertEqual(t, testCase.expectedResult, res)
+	}
+}
+
+func TestIsEqualResources(t *testing.T) {
+	testCases := map[string]struct {
+		current        *types.Resources
+		desired        *types.Resources
+		expectedResult bool
+	}{
+		"test_current_nil_desired_nil": {
+			current:        nil,
+			desired:        nil,
+			expectedResult: true,
+		},
+		"test_current_nil_desired_not_nil": {
+			current:        nil,
+			desired:        &types.Resources{},
+			expectedResult: false,
+		},
+		"test_current_not_nil_desired_nil": {
+			current:        &types.Resources{},
+			desired:        nil,
+			expectedResult: false,
+		},
+		"test_resources_equal": {
+			current: &types.Resources{
+				Memory:            "4m",
+				MemoryReservation: "3m",
+				MemorySwap:        "-1",
+			},
+			desired: &types.Resources{
+				Memory:            "4m",
+				MemoryReservation: "3m",
+				MemorySwap:        "-1",
+			},
+			expectedResult: true,
+		},
+		"test_resources_not_equal": {
+			current: &types.Resources{
+				Memory:            "4m",
+				MemoryReservation: "3m",
+				MemorySwap:        "-1",
+			},
+			desired: &types.Resources{
+				Memory:            "4m",
+				MemoryReservation: "3m",
+			},
+			expectedResult: false,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Log(testName)
+
+		res := isEqualResources(testCase.current, testCase.desired)
+		testutil.AssertEqual(t, testCase.expectedResult, res)
+	}
+}
+
+func TestIsEqualRestartPolicy(t *testing.T) {
+	testCases := map[string]struct {
+		current        *types.RestartPolicy
+		desired        *types.RestartPolicy
+		expectedResult bool
+	}{
+		"test_current_nil_desired_nil": {
+			current:        nil,
+			desired:        nil,
+			expectedResult: true,
+		},
+		"test_current_nil_desired_not_nil": {
+			current:        nil,
+			desired:        &types.RestartPolicy{},
+			expectedResult: false,
+		},
+		"test_current_not_nil_desired_nil": {
+			current:        &types.RestartPolicy{},
+			desired:        nil,
+			expectedResult: false,
+		},
+		"test_restartpolicy_equal": {
+			current: &types.RestartPolicy{
+				MaximumRetryCount: 0,
+				RetryTimeout:      0,
+				Type:              "always",
+			},
+
+			desired: &types.RestartPolicy{
+				MaximumRetryCount: 0,
+				RetryTimeout:      0,
+				Type:              "always",
+			},
+			expectedResult: true,
+		},
+		"test_restartpolicy_not_equal": {
+			current: &types.RestartPolicy{
+				RetryTimeout: 0,
+				Type:         "always",
+			},
+			desired: &types.RestartPolicy{
+				RetryTimeout: 5,
+				Type:         "always",
+			},
+			expectedResult: false,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Log(testName)
+
+		res := isEqualRestartPolicy(testCase.current, testCase.desired)
+		testutil.AssertEqual(t, testCase.expectedResult, res)
+	}
+}
+
+func TestIsEqualLog(t *testing.T) {
+	testCases := map[string]struct {
+		current        *types.LogConfiguration
+		desired        *types.LogConfiguration
+		expectedResult bool
+	}{
+		"test_current_nil_desired_nil": {
+			current:        nil,
+			desired:        nil,
+			expectedResult: true,
+		},
+		"test_current_nil_desired_not_nil": {
+			current:        nil,
+			desired:        &types.LogConfiguration{},
+			expectedResult: false,
+		},
+		"test_current_not_nil_desired_nil": {
+			current:        &types.LogConfiguration{},
+			desired:        nil,
+			expectedResult: false,
+		},
+		"test_current_driverconfig_nil_desired_driverconfig_not_nil": {
+			current: &types.LogConfiguration{
+				DriverConfig: nil,
+				ModeConfig:   &types.LogModeConfiguration{},
+			},
+			desired: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{},
+				ModeConfig:   &types.LogModeConfiguration{},
+			},
+			expectedResult: false,
+		},
+		"test_current_driverconfig_nil_desired_driverconfig_nil": {
+			current: &types.LogConfiguration{
+				DriverConfig: nil,
+				ModeConfig:   &types.LogModeConfiguration{},
+			},
+			desired: &types.LogConfiguration{
+				DriverConfig: nil,
+				ModeConfig:   &types.LogModeConfiguration{},
+			},
+			expectedResult: true,
+		},
+		"test_current_driverconfig_not_nil_desired_driverconfig_nil": {
+			current: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{},
+				ModeConfig:   &types.LogModeConfiguration{},
+			},
+			desired: &types.LogConfiguration{
+				DriverConfig: nil,
+				ModeConfig:   &types.LogModeConfiguration{},
+			},
+			expectedResult: false,
+		},
+		"test_current_driverconfig_not_nil_desired_driverconfig_not_nil_equal": {
+			current: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{
+					Type:     "json-file",
+					MaxFiles: 1,
+					MaxSize:  "100M",
+					RootDir:  "testRootDir",
+				},
+				ModeConfig: &types.LogModeConfiguration{},
+			},
+			desired: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{
+					Type:     "json-file",
+					MaxFiles: 1,
+					MaxSize:  "100M",
+					RootDir:  "testRootDir",
+				},
+				ModeConfig: &types.LogModeConfiguration{},
+			},
+			expectedResult: true,
+		},
+		"test_current_driverconfig_not_nil_desired_driverconfig_not_nil_not_equal": {
+			current: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{
+					Type:     "json-file",
+					MaxFiles: 1,
+					MaxSize:  "100M",
+					RootDir:  "testRootDir",
+				},
+				ModeConfig: &types.LogModeConfiguration{},
+			},
+			desired: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{
+					Type: "json-file",
+				},
+				ModeConfig: &types.LogModeConfiguration{},
+			},
+			expectedResult: false,
+		},
+		"test_current_modeconfig_nil_desired_modeconfig_not_nil": {
+			current: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{},
+				ModeConfig:   nil,
+			},
+			desired: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{},
+				ModeConfig:   &types.LogModeConfiguration{},
+			},
+			expectedResult: false,
+		},
+		"test_current_modeconfig_nil_desired_modeconfig_nil": {
+			current: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{},
+				ModeConfig:   nil,
+			},
+			desired: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{},
+				ModeConfig:   nil,
+			},
+			expectedResult: true,
+		},
+		"test_current_modeconfig_not_nil_desired_modeconfig_nil": {
+			current: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{},
+				ModeConfig:   &types.LogModeConfiguration{},
+			},
+			desired: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{},
+				ModeConfig:   nil,
+			},
+			expectedResult: false,
+		},
+		"test_current_modeconfig_not_nil_desired_modeconfig_not_nil_equal": {
+			current: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{},
+				ModeConfig: &types.LogModeConfiguration{
+					Mode:          "non-blocking",
+					MaxBufferSize: "1m",
+				},
+			},
+			desired: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{},
+				ModeConfig: &types.LogModeConfiguration{
+					Mode:          "non-blocking",
+					MaxBufferSize: "1m",
+				},
+			},
+			expectedResult: true,
+		},
+		"test_current_modeconfig_not_nil_desired_modeconfig_not_nil_not_equal": {
+			current: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{},
+				ModeConfig: &types.LogModeConfiguration{
+					Mode:          "non-blocking",
+					MaxBufferSize: "1m",
+				},
+			},
+			desired: &types.LogConfiguration{
+				DriverConfig: &types.LogDriverConfiguration{},
+				ModeConfig: &types.LogModeConfiguration{
+					Mode:          "non-blocking",
+					MaxBufferSize: "10000m",
+				},
+			},
+			expectedResult: false,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Log(testName)
+
+		res := isEqualLog(testCase.current, testCase.desired)
+		testutil.AssertEqual(t, testCase.expectedResult, res)
+	}
+}
+
+func TestIsEqualIOConfig(t *testing.T) {
+	testCases := map[string]struct {
+		current        *types.IOConfig
+		desired        *types.IOConfig
+		expectedResult bool
+	}{
+		"test_current_nil_desired_nil": {
+			current:        nil,
+			desired:        nil,
+			expectedResult: true,
+		},
+		"test_current_nil_desired_not_nil": {
+			current:        nil,
+			desired:        &types.IOConfig{},
+			expectedResult: false,
+		},
+		"test_current_not_nil_desired_nil": {
+			current:        &types.IOConfig{},
+			desired:        nil,
+			expectedResult: false,
+		},
+		"test_IOConfig_equal_AttachStderr_not_equal": {
+			current: &types.IOConfig{
+				AttachStderr: false,
+
+				OpenStdin: true,
+				Tty:       true,
+			},
+			desired: &types.IOConfig{
+				AttachStderr: true,
+
+				OpenStdin: true,
+				Tty:       true,
+			},
+			expectedResult: true,
+		},
+		"test_IOConfig_not_equal": {
+			current: &types.IOConfig{
+				AttachStderr: false,
+
+				OpenStdin: false,
+				Tty:       false,
+			},
+			desired: &types.IOConfig{
+				AttachStderr: true,
+
+				OpenStdin: true,
+				Tty:       true,
+			},
+			expectedResult: false,
+		},
+		"test_IOConfig_openstdin_not_equal": {
+			current: &types.IOConfig{
+				AttachStderr: false,
+
+				OpenStdin: false,
+				Tty:       false,
+			},
+			desired: &types.IOConfig{
+				AttachStderr: true,
+
+				OpenStdin: true,
+				Tty:       false,
+			},
+			expectedResult: false,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Log(testName)
+
+		res := isEqualIOConfig(testCase.current, testCase.desired)
+		testutil.AssertEqual(t, testCase.expectedResult, res)
+	}
+}

--- a/containerm/util/containers_test.go
+++ b/containerm/util/containers_test.go
@@ -809,3 +809,25 @@ func TestReadContainer(t *testing.T) {
 		})
 	}
 }
+
+func TestAsNamedMap(t *testing.T) {
+	t.Run("TestAsNamedMap", func(t *testing.T) {
+		container := []*types.Container{
+			{
+				DomainName: "testDomainName1",
+				Name:       "testName1",
+			},
+			{
+				DomainName: "testDomainName2",
+				Name:       "testName2",
+			},
+		}
+		res := AsNamedMap(container)
+
+		testutil.AssertEqual(t, "testDomainName1", res["testName1"].DomainName)
+		testutil.AssertEqual(t, "testName1", res["testName1"].Name)
+		testutil.AssertEqual(t, "testDomainName2", res["testName2"].DomainName)
+		testutil.AssertEqual(t, "testName2", res["testName2"].Name)
+		testutil.AssertEqual(t, "", res["testName2"].HostName)
+	})
+}


### PR DESCRIPTION
[#148] Implement automated update of containers

- Updated DeploymentConfig structure: added enable option (true/false), added mode option (init/update), renamed init_dir option to ctr_dir.
- Implemented comparison between an existing container and a desired one. Result of comparison is action to be done in order to achieve desired state.
- Rename InitialDeploy method to Deploy only.
- Implemented logic for automated update of containers via descriptor files.
- Added unit tests to cover updating containers by Deployment Manager service.

Signed-off-by: [Stoyan.Zoubev@bosch.io](mailto:Stoyan.Zoubev@bosch.io)