### PR TITLE
Upgrade google.golang.org/protobuf to version 1.29.1

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -442,11 +442,11 @@ grpc/grpc-go (1.50.1)
 * Project: https://github.com/grpc/grpc-go
 * Source:  https://github.com/grpc/grpc-go/releases/tag/v1.50.1
 
-protocolbuffers/protobuf-go (1.29.0)
+protocolbuffers/protobuf-go (1.30.0)
 
 * License: BSD 3-Clause "New" or "Revised" License
 * Project: https://github.com/protocolbuffers/protobuf-go
-* Source:  https://github.com/protocolbuffers/protobuf-go/releases/tag/v1.29.0
+* Source:  https://github.com/protocolbuffers/protobuf-go/releases/tag/v1.30.0
 
 natefinch/lumberjack (2.0.0)
 

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/sys v0.5.0
 	google.golang.org/grpc v1.50.1
-	google.golang.org/protobuf v1.29.0
+	google.golang.org/protobuf v1.30.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.4.0

--- a/go.sum
+++ b/go.sum
@@ -1852,8 +1852,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-google.golang.org/protobuf v1.29.0 h1:44S3JjaKmLEE4YIkjzexaP+NzZsudE3Zin5Njn/pYX0=
-google.golang.org/protobuf v1.29.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
+google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
[#145] Upgrade google.golang.org/protobuf to version 1.29.1
Upgraded to latest possible version - 1.30.0

Signed-off-by: Daniel Milchev <fixed-term.daniel.milchev@bosch.io>