### PR TITLE
Container status is updated to dead after the container is deleted

### DIFF
--- a/containerm/things/features_container_factory_event_handler.go
+++ b/containerm/things/features_container_factory_event_handler.go
@@ -34,8 +34,8 @@ func (ctrFactory *containerFactoryFeature) handleContainerEvents(ctx context.Con
 						ctrFactory.handleEventCreated(ctrEvent)
 						ctrFactory.handleStateChangedEvent(ctrEvent)
 					case types.EventActionContainersRemoved:
-						ctrFactory.handleEventRemoved(ctrEvent)
 						ctrFactory.handleStateChangedEvent(ctrEvent)
+						ctrFactory.handleEventRemoved(ctrEvent)
 					case types.EventActionContainersRenamed:
 						ctrFactory.handleRenameEvent(ctrEvent)
 					case types.EventActionContainersUpdated:

--- a/containerm/things/features_container_factory_event_handler_test.go
+++ b/containerm/things/features_container_factory_event_handler_test.go
@@ -214,8 +214,8 @@ func mockContainerEventExpectedCreated(t *testing.T, testWg *sync.WaitGroup) err
 
 func mockContainerEventExpectedRemoved(t *testing.T, testWg *sync.WaitGroup) error {
 	testWg.Add(3)
-	mockThing.EXPECT().RemoveFeature(testContainerFeatureID).Times(1).Return(nil).Do(func(id interface{}) { testWg.Done() })
 	mockThing.EXPECT().SetFeatureProperty(testContainerFeatureID, containerFeaturePropertyStatus+"/state", fromAPIContainerState(&types.State{Status: types.Dead})).Do(func(featureId, propertyId, value interface{}) { testWg.Done() })
+	mockThing.EXPECT().RemoveFeature(testContainerFeatureID).Times(1).Return(nil).Do(func(id interface{}) { testWg.Done() })
 	mockContainerStorage.EXPECT().DeleteContainerInfo(testContainer.ID).Do(func(ctrId interface{}) { testWg.Done() })
 	return nil
 }


### PR DESCRIPTION
[#157]  Container status is updated to dead after the container is deleted

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov3@bosch.io>