### PR TITLE
Ensure that container is running after an update without re-creation

### DIFF
--- a/containerm/deployment/deployment_internal.go
+++ b/containerm/deployment/deployment_internal.go
@@ -72,6 +72,7 @@ func (d *deploymentMgr) processUpdate(ctx context.Context, existing []*types.Con
 			recreateAndStartContainer(ctx, d.ctrMgr, current, desired)
 		case util.ActionUpdate:
 			updateContainer(ctx, d.ctrMgr, current, desired)
+			ensureContainerRunning(ctx, d.ctrMgr, current)
 		}
 	}
 	log.Debug("finished containers update")


### PR DESCRIPTION
[#159] Auto deployed container remains stopped after an update

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov3@bosch.io>