### PR TITLE
Extend daemon configuration and dummy implementation for update agent

### DIFF
--- a/containerm/daemon/daemon_command.go
+++ b/containerm/daemon/daemon_command.go
@@ -112,12 +112,6 @@ func setupCommandFlags(cmd *cobra.Command) {
 
 	//TODO remove in M5
 	setupDeprecatedCommandFlags(flagSet)
-
-	// init update agent
-	flagSet.BoolVar(&cfg.UpdateAgentConfig.UpdateAgentEnable, "ua-enable", cfg.UpdateAgentConfig.UpdateAgentEnable, "Enable the update agent for containers")
-	flagSet.StringVar(&cfg.UpdateAgentConfig.DomainName, "ua-domain", cfg.UpdateAgentConfig.DomainName, "Specify the domain name for the containers update agent")
-	flagSet.StringSliceVar(&cfg.UpdateAgentConfig.SystemContainers, "ua-system-containers", cfg.UpdateAgentConfig.SystemContainers, "Specify the list of system containers which shall be skipped during update process by the update agent")
-	flagSet.BoolVar(&cfg.UpdateAgentConfig.VerboseInventory, "ua-verbose-inventory", cfg.UpdateAgentConfig.VerboseInventory, "Enables verbose reporting of current containers by the update agent")
 }
 
 func setupDeprecatedCommandFlags(flagSet *pflag.FlagSet) {
@@ -135,7 +129,7 @@ func setupDeprecatedCommandFlags(flagSet *pflag.FlagSet) {
 	if cfg.ThingsConfig.ThingsConnectionConfig.Transport == nil {
 		cfg.ThingsConfig.ThingsConnectionConfig.Transport = &tlsConfig{}
 	}
-	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.RootCA, "things-conn-root-ca", cfg.ThingsConfig.ThingsConnectionConfig.Transport.RootCA, "Specify the PEM encoded CA certificates file")
-	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientCert, "things-conn-client-cert", cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientCert, "Specify the PEM encoded certificate file to authenticate to the MQTT server/broker")
-	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientKey, "things-conn-client-key", cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientKey, "Specify the PEM encoded unencrypted private key file to authenticate to the MQTT server/broker")
+	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.RootCA, "things-conn-root-ca", cfg.ThingsConfig.ThingsConnectionConfig.Transport.RootCA, "DEPRECATED Specify the PEM encoded CA certificates file")
+	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientCert, "things-conn-client-cert", cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientCert, "DEPRECATED Specify the PEM encoded certificate file to authenticate to the MQTT server/broker")
+	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientKey, "things-conn-client-key", cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientKey, "DEPRECATED Specify the PEM encoded unencrypted private key file to authenticate to the MQTT server/broker")
 }

--- a/containerm/daemon/daemon_command.go
+++ b/containerm/daemon/daemon_command.go
@@ -89,7 +89,7 @@ func setupCommandFlags(cmd *cobra.Command) {
 	flagSet.BoolVar(&cfg.UpdateAgentConfig.UpdateAgentEnable, "ua-enable", cfg.UpdateAgentConfig.UpdateAgentEnable, "Enable the update agent for containers")
 	flagSet.StringVar(&cfg.UpdateAgentConfig.DomainName, "ua-domain", cfg.UpdateAgentConfig.DomainName, "Specify the domain name for the containers update agent")
 	flagSet.StringSliceVar(&cfg.UpdateAgentConfig.SystemContainers, "ua-system-containers", cfg.UpdateAgentConfig.SystemContainers, "Specify the list of system containers which shall be skipped during update process by the update agent")
-	flagSet.BoolVar(&cfg.UpdateAgentConfig.VerboseInventory, "ua-verbose-inventory", cfg.UpdateAgentConfig.VerboseInventory, "Enables verbose reporting of current containers by the update agent")
+	flagSet.BoolVar(&cfg.UpdateAgentConfig.VerboseInventoryReport, "ua-verbose-inventory-report", cfg.UpdateAgentConfig.VerboseInventoryReport, "Enables verbose reporting of current inventory of containers by the update agent")
 
 	// init local communication flags
 	flagSet.StringVar(&cfg.LocalConnection.BrokerURL, "conn-broker-url", cfg.LocalConnection.BrokerURL, "Specify the MQTT broker URL to connect to")

--- a/containerm/daemon/daemon_command.go
+++ b/containerm/daemon/daemon_command.go
@@ -14,7 +14,6 @@ package main
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 func setupCommandFlags(cmd *cobra.Command) {
@@ -106,6 +105,31 @@ func setupCommandFlags(cmd *cobra.Command) {
 
 	//TODO remove in M5
 	setupDeprecatedCommandFlags(flagSet)
+
+	// init update agent
+	flagSet.BoolVar(&cfg.UpdateAgentConfig.UpdateAgentEnable, "ua-enable", cfg.UpdateAgentConfig.UpdateAgentEnable, "Enable the update agent for containers")
+	flagSet.StringVar(&cfg.UpdateAgentConfig.DomainName, "ua-domain", cfg.UpdateAgentConfig.DomainName, "Specify the domain name for the containers update agent")
+	flagSet.StringSliceVar(&cfg.UpdateAgentConfig.SystemContainers, "ua-system-containers", cfg.UpdateAgentConfig.SystemContainers, "Specify the list of system containers which shall be skipped during update process by the update agent")
+	flagSet.BoolVar(&cfg.UpdateAgentConfig.VerboseInventory, "ua-verbose-inventory", cfg.UpdateAgentConfig.VerboseInventory, "Enables verbose reporting of current containers by the update agent")
+
+	flagSet.StringVar(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.BrokerURL, "ua-conn-broker", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.BrokerURL, "Specify the MQTT broker URL to connect to")
+	flagSet.Int64Var(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.KeepAlive, "ua-conn-keep-alive", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.KeepAlive, "Specify the keep alive duration for the MQTT requests in milliseconds")
+	flagSet.Int64Var(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.DisconnectTimeout, "ua-conn-disconnect-timeout", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.DisconnectTimeout, "Specify the disconnection timeout for the MQTT connection in milliseconds")
+	flagSet.StringVar(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.ClientUsername, "ua-conn-client-username", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.ClientUsername, "Specify the MQTT client username to authenticate with")
+	flagSet.StringVar(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.ClientPassword, "ua-conn-client-password", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.ClientPassword, "Specify the MQTT client password to authenticate with")
+	flagSet.Int64Var(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.ConnectTimeout, "ua-conn-connect-timeout", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.ConnectTimeout, "Specify the connect timeout for the MQTT in milliseconds")
+	flagSet.Int64Var(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.AcknowledgeTimeout, "ua-conn-ack-timeout", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.AcknowledgeTimeout, "Specify the acknowledgement timeout for the MQTT requests in milliseconds")
+	flagSet.Int64Var(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.SubscribeTimeout, "ua-conn-sub-timeout", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.SubscribeTimeout, "Specify the subscribe timeout for the MQTT requests in milliseconds")
+	flagSet.Int64Var(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.UnsubscribeTimeout, "ua-conn-unsub-timeout", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.UnsubscribeTimeout, "Specify the unsubscribe timeout for the MQTT requests in milliseconds")
+
+	// init tls support
+	if cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport == nil {
+		cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport = &tlsConfig{}
+	}
+	flagSet.StringVar(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport.RootCA, "ua-conn-root-ca", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport.RootCA, "Specify the PEM encoded CA certificates file")
+	flagSet.StringVar(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport.ClientCert, "ua-conn-client-cert", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport.ClientCert, "Specify the PEM encoded certificate file to authenticate to the MQTT server/broker")
+	flagSet.StringVar(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport.ClientKey, "ua-conn-client-key", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport.ClientKey, "Specify the PEM encoded unencrypted private key file to authenticate to the MQTT server/broker")
+
 }
 
 func setupDeprecatedCommandFlags(flagSet *pflag.FlagSet) {
@@ -123,7 +147,7 @@ func setupDeprecatedCommandFlags(flagSet *pflag.FlagSet) {
 	if cfg.ThingsConfig.ThingsConnectionConfig.Transport == nil {
 		cfg.ThingsConfig.ThingsConnectionConfig.Transport = &tlsConfig{}
 	}
-	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.RootCA, "things-conn-root-ca", cfg.ThingsConfig.ThingsConnectionConfig.Transport.RootCA, "DEPRECATED Specify the PEM encoded CA certificates file")
-	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientCert, "things-conn-client-cert", cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientCert, "DEPRECATED Specify the PEM encoded certificate file to authenticate to the MQTT server/broker")
-	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientKey, "things-conn-client-key", cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientKey, "DEPRECATED Specify the PEM encoded unencrypted private key file to authenticate to the MQTT server/broker")
+	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.RootCA, "things-conn-root-ca", cfg.ThingsConfig.ThingsConnectionConfig.Transport.RootCA, "Specify the PEM encoded CA certificates file")
+	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientCert, "things-conn-client-cert", cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientCert, "Specify the PEM encoded certificate file to authenticate to the MQTT server/broker")
+	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientKey, "things-conn-client-key", cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientKey, "Specify the PEM encoded unencrypted private key file to authenticate to the MQTT server/broker")
 }

--- a/containerm/daemon/daemon_command.go
+++ b/containerm/daemon/daemon_command.go
@@ -14,6 +14,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func setupCommandFlags(cmd *cobra.Command) {
@@ -84,6 +85,12 @@ func setupCommandFlags(cmd *cobra.Command) {
 	flagSet.StringVar(&cfg.ThingsConfig.ThingsMetaPath, "things-home-dir", cfg.ThingsConfig.ThingsMetaPath, "Specify the home directory for the things container management service persistent storage")
 	flagSet.StringSliceVar(&cfg.ThingsConfig.Features, "things-features", cfg.ThingsConfig.Features, "Specify the desired Ditto features that will be registered for the containers Ditto thing")
 
+	// init update agent
+	flagSet.BoolVar(&cfg.UpdateAgentConfig.UpdateAgentEnable, "ua-enable", cfg.UpdateAgentConfig.UpdateAgentEnable, "Enable the update agent for containers")
+	flagSet.StringVar(&cfg.UpdateAgentConfig.DomainName, "ua-domain", cfg.UpdateAgentConfig.DomainName, "Specify the domain name for the containers update agent")
+	flagSet.StringSliceVar(&cfg.UpdateAgentConfig.SystemContainers, "ua-system-containers", cfg.UpdateAgentConfig.SystemContainers, "Specify the list of system containers which shall be skipped during update process by the update agent")
+	flagSet.BoolVar(&cfg.UpdateAgentConfig.VerboseInventory, "ua-verbose-inventory", cfg.UpdateAgentConfig.VerboseInventory, "Enables verbose reporting of current containers by the update agent")
+
 	// init local communication flags
 	flagSet.StringVar(&cfg.LocalConnection.BrokerURL, "conn-broker-url", cfg.LocalConnection.BrokerURL, "Specify the MQTT broker URL to connect to")
 	flagSet.StringVar(&cfg.LocalConnection.KeepAlive, "conn-keep-alive", cfg.LocalConnection.KeepAlive, "Specify the keep alive duration for the MQTT requests as duration string")
@@ -111,25 +118,6 @@ func setupCommandFlags(cmd *cobra.Command) {
 	flagSet.StringVar(&cfg.UpdateAgentConfig.DomainName, "ua-domain", cfg.UpdateAgentConfig.DomainName, "Specify the domain name for the containers update agent")
 	flagSet.StringSliceVar(&cfg.UpdateAgentConfig.SystemContainers, "ua-system-containers", cfg.UpdateAgentConfig.SystemContainers, "Specify the list of system containers which shall be skipped during update process by the update agent")
 	flagSet.BoolVar(&cfg.UpdateAgentConfig.VerboseInventory, "ua-verbose-inventory", cfg.UpdateAgentConfig.VerboseInventory, "Enables verbose reporting of current containers by the update agent")
-
-	flagSet.StringVar(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.BrokerURL, "ua-conn-broker", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.BrokerURL, "Specify the MQTT broker URL to connect to")
-	flagSet.Int64Var(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.KeepAlive, "ua-conn-keep-alive", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.KeepAlive, "Specify the keep alive duration for the MQTT requests in milliseconds")
-	flagSet.Int64Var(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.DisconnectTimeout, "ua-conn-disconnect-timeout", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.DisconnectTimeout, "Specify the disconnection timeout for the MQTT connection in milliseconds")
-	flagSet.StringVar(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.ClientUsername, "ua-conn-client-username", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.ClientUsername, "Specify the MQTT client username to authenticate with")
-	flagSet.StringVar(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.ClientPassword, "ua-conn-client-password", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.ClientPassword, "Specify the MQTT client password to authenticate with")
-	flagSet.Int64Var(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.ConnectTimeout, "ua-conn-connect-timeout", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.ConnectTimeout, "Specify the connect timeout for the MQTT in milliseconds")
-	flagSet.Int64Var(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.AcknowledgeTimeout, "ua-conn-ack-timeout", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.AcknowledgeTimeout, "Specify the acknowledgement timeout for the MQTT requests in milliseconds")
-	flagSet.Int64Var(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.SubscribeTimeout, "ua-conn-sub-timeout", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.SubscribeTimeout, "Specify the subscribe timeout for the MQTT requests in milliseconds")
-	flagSet.Int64Var(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.UnsubscribeTimeout, "ua-conn-unsub-timeout", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.UnsubscribeTimeout, "Specify the unsubscribe timeout for the MQTT requests in milliseconds")
-
-	// init tls support
-	if cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport == nil {
-		cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport = &tlsConfig{}
-	}
-	flagSet.StringVar(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport.RootCA, "ua-conn-root-ca", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport.RootCA, "Specify the PEM encoded CA certificates file")
-	flagSet.StringVar(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport.ClientCert, "ua-conn-client-cert", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport.ClientCert, "Specify the PEM encoded certificate file to authenticate to the MQTT server/broker")
-	flagSet.StringVar(&cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport.ClientKey, "ua-conn-client-key", cfg.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport.ClientKey, "Specify the PEM encoded unencrypted private key file to authenticate to the MQTT server/broker")
-
 }
 
 func setupDeprecatedCommandFlags(flagSet *pflag.FlagSet) {

--- a/containerm/daemon/daemon_config.go
+++ b/containerm/daemon/daemon_config.go
@@ -35,7 +35,7 @@ type config struct {
 
 	ThingsConfig *thingsConfig `json:"things,omitempty"`
 
-	UpdateAgentConfig *updateAgentConfig `json:"updateagent,omitempty"`
+	UpdateAgentConfig *updateAgentConfig `json:"update_agent,omitempty"`
 
 	LocalConnection *localConnectionConfig `json:"connection,omitempty"`
 }
@@ -155,10 +155,10 @@ type thingsConfig struct {
 
 // things client configuration
 type updateAgentConfig struct {
-	UpdateAgentEnable           bool                  `json:"enable,omitempty"`
-	DomainName                  string                `json:"domain,omitempty"`
-	SystemContainers            []string              `json:"system_containers,omitempty"`
-	VerboseInventory            bool                  `json:"verbose_inventory,omitempty"`
+	UpdateAgentEnable bool     `json:"enable,omitempty"`
+	DomainName        string   `json:"domain,omitempty"`
+	SystemContainers  []string `json:"system_containers,omitempty"`
+	VerboseInventory  bool     `json:"verbose_inventory,omitempty"`
 }
 
 // local connection config

--- a/containerm/daemon/daemon_config.go
+++ b/containerm/daemon/daemon_config.go
@@ -35,6 +35,8 @@ type config struct {
 
 	ThingsConfig *thingsConfig `json:"things,omitempty"`
 
+	UpdateAgentConfig *updateAgentConfig `json:"updateagent,omitempty"`
+
 	LocalConnection *localConnectionConfig `json:"connection,omitempty"`
 }
 
@@ -149,6 +151,14 @@ type thingsConfig struct {
 	ThingsMetaPath         string                  `json:"home_dir,omitempty"`
 	Features               []string                `json:"features,omitempty"`
 	ThingsConnectionConfig *thingsConnectionConfig `json:"connection,omitempty"`
+}
+
+// things client configuration
+type updateAgentConfig struct {
+	UpdateAgentEnable           bool                  `json:"enable,omitempty"`
+	DomainName                  string                `json:"domain,omitempty"`
+	SystemContainers            []string              `json:"system_containers,omitempty"`
+	VerboseInventory            bool                  `json:"verbose_inventory,omitempty"`
 }
 
 // local connection config

--- a/containerm/daemon/daemon_config.go
+++ b/containerm/daemon/daemon_config.go
@@ -155,10 +155,10 @@ type thingsConfig struct {
 
 // things client configuration
 type updateAgentConfig struct {
-	UpdateAgentEnable bool     `json:"enable,omitempty"`
-	DomainName        string   `json:"domain,omitempty"`
-	SystemContainers  []string `json:"system_containers,omitempty"`
-	VerboseInventory  bool     `json:"verbose_inventory,omitempty"`
+	UpdateAgentEnable      bool     `json:"enable,omitempty"`
+	DomainName             string   `json:"domain,omitempty"`
+	SystemContainers       []string `json:"system_containers,omitempty"`
+	VerboseInventoryReport bool     `json:"verbose_inventory_report,omitempty"`
 }
 
 // local connection config

--- a/containerm/daemon/daemon_config_default.go
+++ b/containerm/daemon/daemon_config_default.go
@@ -188,18 +188,6 @@ func getDefaultInstance() *config {
 			DomainName:        updateAgentDomainDefault,
 			SystemContainers:  []string{}, // no system containers by defaults
 			VerboseInventory:  updateAgentVerboseInventoryDefault,
-			UpdateAgentConnectionConfig: &mqttConnectionConfig{
-				// use default values as for the things connection
-				BrokerURL:          thingsConnectionBrokerURLDefault,
-				KeepAlive:          thingsConnectionKeepAliveDefault,
-				DisconnectTimeout:  thingsConnectionDisconnectTimeoutDefault,
-				ClientUsername:     thingsConnectionClientUsername,
-				ClientPassword:     thingsConnectionClientPassword,
-				ConnectTimeout:     thingsConnectTimeoutTimeoutDefault,
-				AcknowledgeTimeout: thingsAcknowledgeTimeoutDefault,
-				SubscribeTimeout:   thingsSubscribeTimeoutDefault,
-				UnsubscribeTimeout: thingsUnsubscribeTimeoutDefault,
-			},
 		},
 
 		LocalConnection: &localConnectionConfig{

--- a/containerm/daemon/daemon_config_default.go
+++ b/containerm/daemon/daemon_config_default.go
@@ -189,7 +189,6 @@ func getDefaultInstance() *config {
 			SystemContainers:  []string{}, // no system containers by defaults
 			VerboseInventory:  updateAgentVerboseInventoryDefault,
 		},
-
 		LocalConnection: &localConnectionConfig{
 			BrokerURL:          connectionBrokerURLDefault,
 			KeepAlive:          connectionKeepAliveDefault,

--- a/containerm/daemon/daemon_config_default.go
+++ b/containerm/daemon/daemon_config_default.go
@@ -97,9 +97,9 @@ const (
 	deploymentCtrPathDefault  = "/etc/container-management/containers"
 
 	// default update agent config
-	updateAgentEnableDefault           = false
-	updateAgentDomainDefault           = "containers"
-	updateAgentVerboseInventoryDefault = false
+	updateAgentEnableDefault                 = false
+	updateAgentDomainDefault                 = "containers"
+	updateAgentVerboseInventoryReportDefault = false
 )
 
 var (
@@ -184,10 +184,10 @@ func getDefaultInstance() *config {
 			DeploymentCtrPath:  deploymentCtrPathDefault,
 		},
 		UpdateAgentConfig: &updateAgentConfig{
-			UpdateAgentEnable: updateAgentEnableDefault,
-			DomainName:        updateAgentDomainDefault,
-			SystemContainers:  []string{}, // no system containers by defaults
-			VerboseInventory:  updateAgentVerboseInventoryDefault,
+			UpdateAgentEnable:      updateAgentEnableDefault,
+			DomainName:             updateAgentDomainDefault,
+			SystemContainers:       []string{}, // no system containers by defaults
+			VerboseInventoryReport: updateAgentVerboseInventoryReportDefault,
 		},
 		LocalConnection: &localConnectionConfig{
 			BrokerURL:          connectionBrokerURLDefault,

--- a/containerm/daemon/daemon_config_default.go
+++ b/containerm/daemon/daemon_config_default.go
@@ -95,6 +95,11 @@ const (
 	deploymentModeDefault     = string(deployment.UpdateMode)
 	deploymentMetaPathDefault = managerMetaPathDefault
 	deploymentCtrPathDefault  = "/etc/container-management/containers"
+
+	// default update agent config
+	updateAgentEnableDefault           = false
+	updateAgentDomainDefault           = "containers"
+	updateAgentVerboseInventoryDefault = false
 )
 
 var (
@@ -178,6 +183,25 @@ func getDefaultInstance() *config {
 			DeploymentMetaPath: deploymentMetaPathDefault,
 			DeploymentCtrPath:  deploymentCtrPathDefault,
 		},
+		UpdateAgentConfig: &updateAgentConfig{
+			UpdateAgentEnable: updateAgentEnableDefault,
+			DomainName:        updateAgentDomainDefault,
+			SystemContainers:  []string{}, // no system containers by defaults
+			VerboseInventory:  updateAgentVerboseInventoryDefault,
+			UpdateAgentConnectionConfig: &mqttConnectionConfig{
+				// use default values as for the things connection
+				BrokerURL:          thingsConnectionBrokerURLDefault,
+				KeepAlive:          thingsConnectionKeepAliveDefault,
+				DisconnectTimeout:  thingsConnectionDisconnectTimeoutDefault,
+				ClientUsername:     thingsConnectionClientUsername,
+				ClientPassword:     thingsConnectionClientPassword,
+				ConnectTimeout:     thingsConnectTimeoutTimeoutDefault,
+				AcknowledgeTimeout: thingsAcknowledgeTimeoutDefault,
+				SubscribeTimeout:   thingsSubscribeTimeoutDefault,
+				UnsubscribeTimeout: thingsUnsubscribeTimeoutDefault,
+			},
+		},
+
 		LocalConnection: &localConnectionConfig{
 			BrokerURL:          connectionBrokerURLDefault,
 			KeepAlive:          connectionKeepAliveDefault,

--- a/containerm/daemon/daemon_config_util.go
+++ b/containerm/daemon/daemon_config_util.go
@@ -142,7 +142,7 @@ func extractUpdateAgentOptions(daemonConfig *config) []updateagent.ContainersUpd
 	updateAgentOpts = append(updateAgentOpts,
 		updateagent.WithDomainName(daemonConfig.UpdateAgentConfig.DomainName),
 		updateagent.WithSystemContainers(daemonConfig.UpdateAgentConfig.SystemContainers),
-		updateagent.WithVerboseInventory(daemonConfig.UpdateAgentConfig.VerboseInventory),
+		updateagent.WithVerboseInventoryReport(daemonConfig.UpdateAgentConfig.VerboseInventoryReport),
 
 		updateagent.WithConnectionBroker(daemonConfig.LocalConnection.BrokerURL),
 		updateagent.WithConnectionKeepAlive(parseDuration(daemonConfig.LocalConnection.KeepAlive, connectionKeepAliveDefault)),
@@ -360,7 +360,7 @@ func dumpUpdateAgent(configInstance *config) {
 		if configInstance.UpdateAgentConfig.UpdateAgentEnable {
 			log.Debug("[daemon_cfg][ua-domain] : %s", configInstance.UpdateAgentConfig.DomainName)
 			log.Debug("[daemon_cfg][ua-system-containers] : %s", configInstance.UpdateAgentConfig.SystemContainers)
-			log.Debug("[daemon_cfg][ua-verbose-inventory] : %v", configInstance.UpdateAgentConfig.VerboseInventory)
+			log.Debug("[daemon_cfg][ua-verbose-inventory-report] : %v", configInstance.UpdateAgentConfig.VerboseInventoryReport)
 		}
 	}
 }

--- a/containerm/daemon/daemon_config_util.go
+++ b/containerm/daemon/daemon_config_util.go
@@ -28,6 +28,7 @@ import (
 	"github.com/eclipse-kanto/container-management/containerm/network"
 	"github.com/eclipse-kanto/container-management/containerm/server"
 	"github.com/eclipse-kanto/container-management/containerm/things"
+	"github.com/eclipse-kanto/container-management/containerm/updateagent"
 	"github.com/spf13/pflag"
 )
 
@@ -143,6 +144,30 @@ func extractThingsOptions(daemonConfig *config) []things.ContainerThingsManagerO
 		thingsOpts = append(thingsOpts, things.WithTLSConfig(lcc.Transport.RootCA, lcc.Transport.ClientCert, lcc.Transport.ClientKey))
 	}
 	return thingsOpts
+}
+
+func extractUpdateAgentOptions(daemonConfig *config) []updateagent.ContainersUpdateAgentOpt {
+	updateAgentOpts := []updateagent.ContainersUpdateAgentOpt{}
+	updateAgentOpts = append(updateAgentOpts,
+		updateagent.WithDomainName(daemonConfig.UpdateAgentConfig.DomainName),
+		updateagent.WithSystemContainers(daemonConfig.UpdateAgentConfig.SystemContainers),
+		updateagent.WithVerboseInventory(daemonConfig.UpdateAgentConfig.VerboseInventory),
+
+		updateagent.WithConnectionBroker(daemonConfig.UpdateAgentConfig.UpdateAgentConnectionConfig.BrokerURL),
+		updateagent.WithConnectionKeepAlive(time.Duration(daemonConfig.UpdateAgentConfig.UpdateAgentConnectionConfig.KeepAlive)*time.Millisecond),
+		updateagent.WithConnectionDisconnectTimeout(time.Duration(daemonConfig.UpdateAgentConfig.UpdateAgentConnectionConfig.DisconnectTimeout)*time.Millisecond),
+		updateagent.WithConnectionClientUsername(daemonConfig.UpdateAgentConfig.UpdateAgentConnectionConfig.ClientUsername),
+		updateagent.WithConnectionClientPassword(daemonConfig.UpdateAgentConfig.UpdateAgentConnectionConfig.ClientPassword),
+		updateagent.WithConnectionConnectTimeout(time.Duration(daemonConfig.UpdateAgentConfig.UpdateAgentConnectionConfig.ConnectTimeout)*time.Millisecond),
+		updateagent.WithConnectionAcknowledgeTimeout(time.Duration(daemonConfig.UpdateAgentConfig.UpdateAgentConnectionConfig.AcknowledgeTimeout)*time.Millisecond),
+		updateagent.WithConnectionSubscribeTimeout(time.Duration(daemonConfig.UpdateAgentConfig.UpdateAgentConnectionConfig.SubscribeTimeout)*time.Millisecond),
+		updateagent.WithConnectionUnsubscribeTimeout(time.Duration(daemonConfig.UpdateAgentConfig.UpdateAgentConnectionConfig.UnsubscribeTimeout)*time.Millisecond),
+	)
+	transport := daemonConfig.UpdateAgentConfig.UpdateAgentConnectionConfig.Transport
+	if transport != nil {
+		updateAgentOpts = append(updateAgentOpts, updateagent.WithTLSConfig(transport.RootCA, transport.ClientCert, transport.ClientKey))
+	}
+	return updateAgentOpts
 }
 
 func extractDeploymentMgrOptions(daemonConfig *config) []deployment.Opt {

--- a/containerm/daemon/daemon_internal.go
+++ b/containerm/daemon/daemon_internal.go
@@ -40,16 +40,14 @@ func (d *daemon) start() error {
 	}
 
 	if d.config.ThingsConfig.ThingsEnable {
-		err := d.startThingsManagers()
-		if err != nil {
+		if err := d.startThingsManagers(); err != nil {
 			log.ErrorErr(err, "could not start the Things Container Manager Services")
 		}
 	}
 
 	if d.config.UpdateAgentConfig.UpdateAgentEnable {
 		log.Debug("Containers Update Agent is enabled.")
-		err := d.startUpdateAgents()
-		if err != nil {
+		if err := d.startUpdateAgents(); err != nil {
 			log.ErrorErr(err, "could not start the Containers Update Agent Services")
 		}
 	} else {
@@ -57,7 +55,6 @@ func (d *daemon) start() error {
 	}
 
 	return d.startGrpcServers()
-
 }
 
 func (d *daemon) stop() {

--- a/containerm/daemon/daemon_internal_init.go
+++ b/containerm/daemon/daemon_internal_init.go
@@ -60,6 +60,13 @@ func (d *daemon) init() {
 		log.Info("Deployment Manager is disabled - no Deployment Manager Services will be registered. If you would like to enable Deployment support, please, reconfigure deployment-enable to true")
 	}
 
+	//init update agent manager service
+	if daemonConfig.UpdateAgentConfig.UpdateAgentEnable {
+		initService(ctx, d, registrationsMap, registry.UpdateAgentService)
+	} else {
+		log.Info("Containers Update Agent is disabled - no Update Agent Services will be registered. If you would like to enable Update Agent support, please, reconfigure ua-enable to true")
+	}
+
 	//init grpc services
 	initService(ctx, d, registrationsMap, registry.GRPCService)
 
@@ -92,6 +99,8 @@ func initService(ctx context.Context, d *daemon, registrationsMap map[registry.T
 		case registry.DeploymentManagerService:
 			config = extractDeploymentMgrOptions(d.config)
 			break
+		case registry.UpdateAgentService:
+			config = extractUpdateAgentOptions(d.config)
 		default:
 			config = nil
 		}

--- a/containerm/daemon/daemon_test.go
+++ b/containerm/daemon/daemon_test.go
@@ -453,6 +453,22 @@ func TestSetCommandFlags(t *testing.T) {
 			flag:         "conn-client-key",
 			expectedType: reflect.String.String(),
 		},
+		"test_flags-ua-enable": {
+			flag:         "ua-enable",
+			expectedType: reflect.Bool.String(),
+		},
+		"test_flags-ua-domain": {
+			flag:         "ua-domain",
+			expectedType: reflect.String.String(),
+		},
+		"test_flags-ua-system-containers": {
+			flag:         "ua-system-containers",
+			expectedType: "stringSlice",
+		},
+		"test_flags-ua-verbose-inventory": {
+			flag:         "ua-verbose-inventory",
+			expectedType: reflect.Bool.String(),
+		},
 	}
 
 	for testName, testCase := range tests {

--- a/containerm/pkg/testutil/config/daemon-config.json
+++ b/containerm/pkg/testutil/config/daemon-config.json
@@ -70,6 +70,13 @@
     "home_dir": "/var/lib/container-management",
     "ctr_dir": "/etc/container-management/containers"
   },
+  "update_agent": {
+    "enable": false,
+    "domain": "containers",
+    "system_containers": [],
+    "verbose_inventory": false
+  }
+}
   "connection": {
     "broker_url": "tcp://localhost:1883",
     "keep_alive": "20s",

--- a/containerm/pkg/testutil/config/daemon-config.json
+++ b/containerm/pkg/testutil/config/daemon-config.json
@@ -75,8 +75,7 @@
     "domain": "containers",
     "system_containers": [],
     "verbose_inventory": false
-  }
-}
+  },
   "connection": {
     "broker_url": "tcp://localhost:1883",
     "keep_alive": "20s",

--- a/containerm/registry/registry.go
+++ b/containerm/registry/registry.go
@@ -44,6 +44,8 @@ const (
 	GRPCServer Type = "container-management.server.grpc.v1"
 	// DeploymentManagerService implements THE container deployment manager service
 	DeploymentManagerService Type = "container-management.service.deployment.ctrs.manager.v1"
+	// UpdateAgentService implements the UpdateAgent API for containers domain
+	UpdateAgentService Type = "container-management.service.ctrs.updateagent.v1"
 )
 
 // Registration holds service's information that will be added to the registry

--- a/containerm/updateagent/update_agent_init.go
+++ b/containerm/updateagent/update_agent_init.go
@@ -27,7 +27,7 @@ import (
 func newUpdateAgent(mgr mgr.ContainerManager, eventsMgr events.ContainerEventsManager,
 	domainName string,
 	systemContainers []string,
-	verboseInventory bool,
+	verboseInventoryReport bool,
 	broker string,
 	keepAlive time.Duration,
 	disconnectTimeout time.Duration,
@@ -51,16 +51,16 @@ func newUpdateAgent(mgr mgr.ContainerManager, eventsMgr events.ContainerEventsMa
 		UnsubscribeTimeout: unsubscribeTimeout.Milliseconds(),
 	})
 
-	return agent.NewUpdateAgent(mqttClient, newUpdateManager(mgr, eventsMgr, domainName, systemContainers, verboseInventory)), nil
+	return agent.NewUpdateAgent(mqttClient, newUpdateManager(mgr, eventsMgr, domainName, systemContainers, verboseInventoryReport)), nil
 }
 
 // newUpdateManager instantiates a new update manager instance
 func newUpdateManager(mgr mgr.ContainerManager, eventsMgr events.ContainerEventsManager,
-	domainName string, systemContainers []string, verboseContainers bool) api.UpdateManager {
+	domainName string, systemContainers []string, verboseInventoryReport bool) api.UpdateManager {
 	return &containersUpdateManager{
-		domainName:        domainName,
-		systemContainers:  systemContainers,
-		verboseContainers: verboseContainers,
+		domainName:             domainName,
+		systemContainers:       systemContainers,
+		verboseInventoryReport: verboseInventoryReport,
 
 		mgr:                   mgr,
 		eventsMgr:             eventsMgr,
@@ -86,7 +86,7 @@ func registryInit(registryCtx *registry.ServiceRegistryContext) (interface{}, er
 	return newUpdateAgent(mgrService.(mgr.ContainerManager), eventsMgr.(events.ContainerEventsManager),
 		uaOpts.domainName,
 		uaOpts.systemContainers,
-		uaOpts.verboseInventory,
+		uaOpts.verboseInventoryReport,
 		uaOpts.broker,
 		uaOpts.keepAlive,
 		uaOpts.disconnectTimeout,

--- a/containerm/updateagent/update_agent_init.go
+++ b/containerm/updateagent/update_agent_init.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package updateagent
+
+import (
+	"time"
+
+	"github.com/eclipse-kanto/container-management/containerm/events"
+	"github.com/eclipse-kanto/container-management/containerm/mgr"
+	"github.com/eclipse-kanto/container-management/containerm/registry"
+
+	"github.com/eclipse-kanto/update-manager/api"
+	"github.com/eclipse-kanto/update-manager/api/agent"
+	"github.com/eclipse-kanto/update-manager/mqtt"
+)
+
+func newUpdateAgent(mgr mgr.ContainerManager, eventsMgr events.ContainerEventsManager,
+	domainName string,
+	systemContainers []string,
+	verboseInventory bool,
+	brokerURL string,
+	keepAlive time.Duration,
+	disconnectTimeout time.Duration,
+	clientUsername string,
+	clientPassword string,
+	connectTimeout time.Duration,
+	acknowledgeTimeout time.Duration,
+	subscribeTimeout time.Duration,
+	unsubscribeTimeout time.Duration,
+	tlsConfig *tlsConfig) (api.UpdateAgent, error) {
+
+	mqttClient := mqtt.NewUpdateAgentClient(domainName, &mqtt.ConnectionConfig{
+		BrokerURL:          brokerURL,
+		KeepAlive:          keepAlive.Milliseconds(),
+		DisconnectTimeout:  disconnectTimeout.Milliseconds(),
+		ClientUsername:     clientUsername,
+		ClientPassword:     clientPassword,
+		ConnectTimeout:     connectTimeout.Milliseconds(),
+		AcknowledgeTimeout: acknowledgeTimeout.Milliseconds(),
+		SubscribeTimeout:   subscribeTimeout.Milliseconds(),
+		UnsubscribeTimeout: unsubscribeTimeout.Milliseconds(),
+	})
+
+	return agent.NewUpdateAgent(mqttClient, newUpdateManager(mgr, eventsMgr, domainName, systemContainers, verboseInventory)), nil
+}
+
+// newUpdateManager instantiates a new update manager instance
+func newUpdateManager(mgr mgr.ContainerManager, eventsMgr events.ContainerEventsManager,
+	domainName string, systemContainers []string, verboseContainers bool) api.UpdateManager {
+	return &containersUpdateManager{
+		domainName:        domainName,
+		systemContainers:  systemContainers,
+		verboseContainers: verboseContainers,
+
+		mgr:                   mgr,
+		eventsMgr:             eventsMgr,
+		createUpdateOperation: newOperation,
+	}
+}
+
+func registryInit(registryCtx *registry.ServiceRegistryContext) (interface{}, error) {
+	eventsMgr, err := registryCtx.Get(registry.EventsManagerService)
+	if err != nil {
+		return nil, err
+	}
+	mgrService, err := registryCtx.Get(registry.ContainerManagerService)
+	if err != nil {
+		return nil, err
+	}
+
+	// init options processing
+	uaOpts := &updateAgentOpts{}
+	if err := applyOptsUpdateAgent(uaOpts, registryCtx.Config.([]ContainersUpdateAgentOpt)...); err != nil {
+		return nil, err
+	}
+	return newUpdateAgent(mgrService.(mgr.ContainerManager), eventsMgr.(events.ContainerEventsManager),
+		uaOpts.domainName,
+		uaOpts.systemContainers,
+		uaOpts.verboseInventory,
+		uaOpts.broker,
+		uaOpts.keepAlive,
+		uaOpts.disconnectTimeout,
+		uaOpts.clientUsername,
+		uaOpts.clientPassword,
+		uaOpts.connectTimeout,
+		uaOpts.acknowledgeTimeout,
+		uaOpts.subscribeTimeout,
+		uaOpts.unsubscribeTimeout,
+		uaOpts.tlsConfig,
+	)
+}

--- a/containerm/updateagent/update_agent_init.go
+++ b/containerm/updateagent/update_agent_init.go
@@ -28,7 +28,7 @@ func newUpdateAgent(mgr mgr.ContainerManager, eventsMgr events.ContainerEventsMa
 	domainName string,
 	systemContainers []string,
 	verboseInventory bool,
-	brokerURL string,
+	broker string,
 	keepAlive time.Duration,
 	disconnectTimeout time.Duration,
 	clientUsername string,
@@ -40,11 +40,11 @@ func newUpdateAgent(mgr mgr.ContainerManager, eventsMgr events.ContainerEventsMa
 	tlsConfig *tlsConfig) (api.UpdateAgent, error) {
 
 	mqttClient := mqtt.NewUpdateAgentClient(domainName, &mqtt.ConnectionConfig{
-		BrokerURL:          brokerURL,
+		Broker:             broker,
 		KeepAlive:          keepAlive.Milliseconds(),
 		DisconnectTimeout:  disconnectTimeout.Milliseconds(),
-		ClientUsername:     clientUsername,
-		ClientPassword:     clientPassword,
+		Username:           clientUsername,
+		Password:           clientPassword,
 		ConnectTimeout:     connectTimeout.Milliseconds(),
 		AcknowledgeTimeout: acknowledgeTimeout.Milliseconds(),
 		SubscribeTimeout:   subscribeTimeout.Milliseconds(),

--- a/containerm/updateagent/update_agent_opts.go
+++ b/containerm/updateagent/update_agent_opts.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package updateagent
+
+import (
+	"time"
+)
+
+// ContainersUpdateAgentOpt represents the available configuration options for the Containers UpdateAgent service
+type ContainersUpdateAgentOpt func(updateAgentOptions *updateAgentOpts) error
+
+type updateAgentOpts struct {
+	domainName         string
+	systemContainers   []string
+	verboseInventory   bool
+	broker             string
+	keepAlive          time.Duration
+	disconnectTimeout  time.Duration
+	clientUsername     string
+	clientPassword     string
+	connectTimeout     time.Duration
+	acknowledgeTimeout time.Duration
+	subscribeTimeout   time.Duration
+	unsubscribeTimeout time.Duration
+	tlsConfig          *tlsConfig
+}
+
+// tls-secured communication config
+type tlsConfig struct {
+	RootCA     string
+	ClientCert string
+	ClientKey  string
+}
+
+func applyOptsUpdateAgent(updateAgentOpts *updateAgentOpts, opts ...ContainersUpdateAgentOpt) error {
+	for _, o := range opts {
+		if err := o(updateAgentOpts); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WithDomainName configures the domain name for the containers update agent
+func WithDomainName(domain string) ContainersUpdateAgentOpt {
+	return func(updateAgentOptions *updateAgentOpts) error {
+		updateAgentOptions.domainName = domain
+		return nil
+	}
+}
+
+// WithSystemContainers configures the list of system containers (names) that will not be processed by the containers update agent
+func WithSystemContainers(systemContainers []string) ContainersUpdateAgentOpt {
+	return func(updateAgentOptions *updateAgentOpts) error {
+		updateAgentOptions.systemContainers = systemContainers
+		return nil
+	}
+}
+
+// WithVerboseInventory enables / disables verbose inventory reporting of current containers
+func WithVerboseInventory(verboseInventory bool) ContainersUpdateAgentOpt {
+	return func(updateAgentOptions *updateAgentOpts) error {
+		updateAgentOptions.verboseInventory = verboseInventory
+		return nil
+	}
+}
+
+// WithConnectionBroker configures the broker, where the connection will be established
+func WithConnectionBroker(broker string) ContainersUpdateAgentOpt {
+	return func(updateAgentOptions *updateAgentOpts) error {
+		updateAgentOptions.broker = broker
+		return nil
+	}
+}
+
+// WithConnectionKeepAlive configures the time between between each check for the connection presence
+func WithConnectionKeepAlive(keepAlive time.Duration) ContainersUpdateAgentOpt {
+	return func(updateAgentOptions *updateAgentOpts) error {
+		updateAgentOptions.keepAlive = keepAlive
+		return nil
+	}
+}
+
+// WithConnectionDisconnectTimeout configures the duration of inactivity before disconnecting from the broker
+func WithConnectionDisconnectTimeout(disconnectTimeout time.Duration) ContainersUpdateAgentOpt {
+	return func(updateAgentOptions *updateAgentOpts) error {
+		updateAgentOptions.disconnectTimeout = disconnectTimeout
+		return nil
+	}
+}
+
+// WithConnectionClientUsername configures the client username used when establishing connection to the broker
+func WithConnectionClientUsername(username string) ContainersUpdateAgentOpt {
+	return func(updateAgentOptions *updateAgentOpts) error {
+		updateAgentOptions.clientUsername = username
+		return nil
+	}
+}
+
+// WithConnectionClientPassword configures the client password used when establishing connection to the broker
+func WithConnectionClientPassword(password string) ContainersUpdateAgentOpt {
+	return func(updateAgentOptions *updateAgentOpts) error {
+		updateAgentOptions.clientPassword = password
+		return nil
+	}
+}
+
+// WithConnectionConnectTimeout configures the timeout before terminating the connect attempt
+func WithConnectionConnectTimeout(connectTimeout time.Duration) ContainersUpdateAgentOpt {
+	return func(updateAgentOptions *updateAgentOpts) error {
+		updateAgentOptions.connectTimeout = connectTimeout
+		return nil
+	}
+}
+
+// WithConnectionAcknowledgeTimeout configures the timeout for the acknowledge receival
+func WithConnectionAcknowledgeTimeout(acknowledgeTimeout time.Duration) ContainersUpdateAgentOpt {
+	return func(updateAgentOptions *updateAgentOpts) error {
+		updateAgentOptions.acknowledgeTimeout = acknowledgeTimeout
+		return nil
+	}
+}
+
+// WithConnectionSubscribeTimeout configures the timeout before terminating the subscribe attempt
+func WithConnectionSubscribeTimeout(subscribeTimeout time.Duration) ContainersUpdateAgentOpt {
+	return func(updateAgentOptions *updateAgentOpts) error {
+		updateAgentOptions.subscribeTimeout = subscribeTimeout
+		return nil
+	}
+}
+
+// WithConnectionUnsubscribeTimeout configures the timeout before terminating the unsubscribe attempt
+func WithConnectionUnsubscribeTimeout(unsubscribeTimeout time.Duration) ContainersUpdateAgentOpt {
+	return func(updateAgentOptions *updateAgentOpts) error {
+		updateAgentOptions.unsubscribeTimeout = unsubscribeTimeout
+		return nil
+	}
+}
+
+// WithTLSConfig configures the CA certificate for TLS communication
+func WithTLSConfig(rootCA, clientCert, clientKey string) ContainersUpdateAgentOpt {
+	return func(updateAgentOptions *updateAgentOpts) error {
+		updateAgentOptions.tlsConfig = &tlsConfig{
+			RootCA:     rootCA,
+			ClientCert: clientCert,
+			ClientKey:  clientKey,
+		}
+		return nil
+	}
+}

--- a/containerm/updateagent/update_agent_opts.go
+++ b/containerm/updateagent/update_agent_opts.go
@@ -20,19 +20,19 @@ import (
 type ContainersUpdateAgentOpt func(updateAgentOptions *updateAgentOpts) error
 
 type updateAgentOpts struct {
-	domainName         string
-	systemContainers   []string
-	verboseInventory   bool
-	broker             string
-	keepAlive          time.Duration
-	disconnectTimeout  time.Duration
-	clientUsername     string
-	clientPassword     string
-	connectTimeout     time.Duration
-	acknowledgeTimeout time.Duration
-	subscribeTimeout   time.Duration
-	unsubscribeTimeout time.Duration
-	tlsConfig          *tlsConfig
+	domainName             string
+	systemContainers       []string
+	verboseInventoryReport bool
+	broker                 string
+	keepAlive              time.Duration
+	disconnectTimeout      time.Duration
+	clientUsername         string
+	clientPassword         string
+	connectTimeout         time.Duration
+	acknowledgeTimeout     time.Duration
+	subscribeTimeout       time.Duration
+	unsubscribeTimeout     time.Duration
+	tlsConfig              *tlsConfig
 }
 
 // tls-secured communication config
@@ -67,10 +67,10 @@ func WithSystemContainers(systemContainers []string) ContainersUpdateAgentOpt {
 	}
 }
 
-// WithVerboseInventory enables / disables verbose inventory reporting of current containers
-func WithVerboseInventory(verboseInventory bool) ContainersUpdateAgentOpt {
+// WithVerboseInventoryReport enables / disables verbose inventory reporting of current containers
+func WithVerboseInventoryReport(verboseInventoryReport bool) ContainersUpdateAgentOpt {
 	return func(updateAgentOptions *updateAgentOpts) error {
-		updateAgentOptions.verboseInventory = verboseInventory
+		updateAgentOptions.verboseInventoryReport = verboseInventoryReport
 		return nil
 	}
 }

--- a/containerm/updateagent/update_agent_service.go
+++ b/containerm/updateagent/update_agent_service.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package updateagent
+
+import (
+	"github.com/eclipse-kanto/container-management/containerm/registry"
+)
+
+const (
+	// ContainerUpdateAgentServiceLocalID is the ID of the local container update agent
+	ContainerUpdateAgentServiceLocalID = "container-management.service.local.v1.service-container-update-agent"
+)
+
+func init() {
+	registry.Register(&registry.Registration{
+		ID:       ContainerUpdateAgentServiceLocalID,
+		Type:     registry.UpdateAgentService,
+		InitFunc: registryInit,
+	})
+}

--- a/containerm/updateagent/update_manager.go
+++ b/containerm/updateagent/update_manager.go
@@ -31,9 +31,9 @@ const (
 )
 
 type containersUpdateManager struct {
-	domainName        string
-	systemContainers  []string
-	verboseContainers bool
+	domainName             string
+	systemContainers       []string
+	verboseInventoryReport bool
 
 	mgr       mgr.ContainerManager
 	eventsMgr events.ContainerEventsManager
@@ -143,7 +143,7 @@ func (updMgr *containersUpdateManager) getCurrentContainers() []*types.SoftwareN
 		log.ErrorErr(err, "could not list all existing containers")
 		return nil
 	}
-	// TODO implement function fromContainers(containers, updMgr.verboseContainers)
+	// TODO implement function fromContainers(containers, updMgr.verboseInventoryReport)
 	return nil
 }
 

--- a/containerm/updateagent/update_manager.go
+++ b/containerm/updateagent/update_manager.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package updateagent
+
+import (
+	"context"
+	"sync"
+
+	"github.com/eclipse-kanto/container-management/containerm/events"
+	"github.com/eclipse-kanto/container-management/containerm/log"
+	"github.com/eclipse-kanto/container-management/containerm/mgr"
+	"github.com/eclipse-kanto/container-management/containerm/version"
+
+	"github.com/eclipse-kanto/update-manager/api"
+	"github.com/eclipse-kanto/update-manager/api/types"
+)
+
+const (
+	updateManagerName = "Eclipse Kanto Containers Update Agent"
+	parameterDomain   = "domain"
+)
+
+type containersUpdateManager struct {
+	domainName        string
+	systemContainers  []string
+	verboseContainers bool
+
+	mgr       mgr.ContainerManager
+	eventsMgr events.ContainerEventsManager
+
+	applyLock             sync.Mutex
+	eventCallback         api.UpdateManagerCallback
+	createUpdateOperation createUpdateOperation
+	operation             UpdateOperation
+}
+
+// Name returns the name of this update manager, e.g. "containers".
+func (updMgr *containersUpdateManager) Name() string {
+	return updMgr.domainName
+}
+
+// Apply triggers the update operation with the given activity ID and desired state with containers.
+// First, it validates the received desired state specification and identifies the actions to be applied.
+// If errors are detected, then IDENTIFICATION_FAILED feedback status is reported and operation finishes unsuccessfully.
+// Otherwise, IDENTIFIED feedback status with identified actions is reported and it will wait for further commands to proceed.
+func (updMgr *containersUpdateManager) Apply(ctx context.Context, activityID string, desiredState *types.DesiredState) {
+	updMgr.applyLock.Lock()
+	defer updMgr.applyLock.Unlock()
+
+	log.Debug("processing desired state - start")
+	// create operation instance
+	updMgr.operation = updMgr.createUpdateOperation(updMgr, activityID, desiredState)
+
+	// identification phase
+	updMgr.operation.Feedback(types.StatusIdentifying, "", "")
+	if err := updMgr.operation.Identify(); err != nil {
+		updMgr.operation.Feedback(types.StatusIdentificationFailed, err.Error(), "")
+		return
+	}
+	updMgr.operation.Feedback(types.StatusIdentified, "", "")
+
+	log.Debug("processing desired state - identification phase completed, waiting for commands...")
+}
+
+// Command processes received desired state command.
+func (updMgr *containersUpdateManager) Command(ctx context.Context, activityID string, command *types.DesiredStateCommand) {
+	if command == nil {
+		log.Error("Skipping received command for activityId %s, but no payload.", activityID)
+		return
+	}
+	updMgr.applyLock.Lock()
+	defer updMgr.applyLock.Unlock()
+
+	operation := updMgr.operation
+	if operation == nil {
+		log.Warn("Ignoring received command %s for baseline %s and activityId %s, but no operation in progress.", command.Command, command.Baseline, activityID)
+		return
+	}
+	if operation.GetActivityID() != activityID {
+		log.Warn("Ignoring received command %s for baseline %s and activityId %s, but not matching operation in progress [%s].",
+			command.Command, command.Baseline, activityID, operation.GetActivityID())
+		return
+	}
+	operation.Execute(command.Command, command.Baseline)
+}
+
+// Get returns the current state as an inventory graph.
+// The inventory graph includes a root software node (type APPLICATION) representing the update agent itself and a list of software nodes (type CONTAINER) representing the available containers.
+func (updMgr *containersUpdateManager) Get(ctx context.Context, activityID string) (*types.Inventory, error) {
+	return toInventory(updMgr.asSoftwareNode(), updMgr.getCurrentContainers()), nil
+}
+
+func toInventory(swNodeAgent *types.SoftwareNode, swNodeContainers []*types.SoftwareNode) *types.Inventory {
+	swNodes := []*types.SoftwareNode{swNodeAgent}
+	associations := []*types.Association{}
+	if len(swNodeContainers) > 0 {
+		swNodes = append(swNodes, swNodeContainers...)
+
+		for _, swNodeContainer := range swNodeContainers {
+			swNodeContainer.ID = swNodeAgent.Parameters[0].Value + ":" + swNodeContainer.ID
+			associations = append(associations, &types.Association{
+				SourceID: swNodeAgent.ID,
+				TargetID: swNodeContainer.ID,
+			})
+		}
+	}
+	return &types.Inventory{
+		SoftwareNodes: swNodes,
+		Associations:  associations,
+	}
+}
+
+func (updMgr *containersUpdateManager) asSoftwareNode() *types.SoftwareNode {
+	return &types.SoftwareNode{
+		InventoryNode: types.InventoryNode{
+			ID:      updMgr.Name() + "-update-agent",
+			Version: version.ProjectVersion,
+			Name:    updateManagerName,
+			Parameters: []*types.KeyValuePair{
+				{
+					Key:   parameterDomain,
+					Value: updMgr.Name(),
+				},
+			},
+		},
+		Type: types.SoftwareTypeApplication,
+	}
+}
+
+func (updMgr *containersUpdateManager) getCurrentContainers() []*types.SoftwareNode {
+	_, err := updMgr.mgr.List(context.Background())
+	if err != nil {
+		log.ErrorErr(err, "could not list all existing containers")
+		return nil
+	}
+	// TODO implement function fromContainers(containers, updMgr.verboseContainers)
+	return nil
+}
+
+// Dispose releases all resources used by this instance
+func (updMgr *containersUpdateManager) Dispose() error {
+	return nil
+}
+
+// WatchEvents subscribes for events that update the current state inventory
+func (updMgr *containersUpdateManager) WatchEvents(ctx context.Context) {
+	// no container events handled yet - current state inventory reported only on initial start or explicit get request
+}
+
+// SetCallback sets the callback instance that is used for desired state feedback / current state notifications.
+// It is set when the update agent instance is started
+func (updMgr *containersUpdateManager) SetCallback(callback api.UpdateManagerCallback) {
+	updMgr.eventCallback = callback
+}

--- a/containerm/updateagent/update_operation.go
+++ b/containerm/updateagent/update_operation.go
@@ -71,7 +71,7 @@ func (o *operation) Identify() error {
 		o.ctx = context.Background()
 	}
 	// TODO compare current vs. desired containers and identify actions
-	return errors.New("Not implemented yet!")
+	return errors.New("Not implemented yet")
 }
 
 // Execute executes each COMMAND (download, update, activate, etc) phase, triggered per baseline or for all the identified actions

--- a/containerm/updateagent/update_operation.go
+++ b/containerm/updateagent/update_operation.go
@@ -50,13 +50,13 @@ type UpdateOperation interface {
 	Feedback(status types.StatusType, message string, baseline string)
 }
 
-type createUpdateOperation func(*containersUpdateManager, string, interface{}) UpdateOperation
+type createUpdateOperation func(*containersUpdateManager, string, *types.DesiredState) UpdateOperation
 
-func newOperation(updMgr *containersUpdateManager, activityID string, desiredState interface{}) UpdateOperation {
+func newOperation(updMgr *containersUpdateManager, activityID string, desiredState *types.DesiredState) UpdateOperation {
 	return &operation{
 		updateManager: updMgr,
 		activityID:    activityID,
-		desiredState:  desiredState.(*types.DesiredState),
+		desiredState:  desiredState,
 	}
 }
 
@@ -246,7 +246,7 @@ func (o *operation) cleanup(baseline string) {
 	log.Debug("cleanup for baseline %s - done...", baseline)
 }
 
-// Feeback sends desired state feedback responses, baseline parameter is optional
+// Feedback sends desired state feedback responses, baseline parameter is optional
 func (o *operation) Feedback(status types.StatusType, message string, baseline string) {
 	o.updateManager.eventCallback.HandleDesiredStateFeedbackEvent(o.updateManager.domainName, o.activityID, baseline, status, message, o.toFeedbackActions())
 }

--- a/containerm/updateagent/update_operation.go
+++ b/containerm/updateagent/update_operation.go
@@ -1,0 +1,273 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package updateagent
+
+import (
+	"context"
+	"errors"
+
+	"github.com/eclipse-kanto/container-management/containerm/log"
+
+	"github.com/eclipse-kanto/update-manager/api/types"
+)
+
+type containerAction struct {
+	// TODO add current / desired container + actionType
+	feedbackAction *types.Action
+}
+
+type baselineAction struct {
+	baseline string
+	status   types.StatusType
+	actions  []*containerAction
+}
+
+type operation struct {
+	ctx           context.Context
+	updateManager *containersUpdateManager
+	activityID    string
+	desiredState  *types.DesiredState
+
+	allActions      *baselineAction
+	baselineActions map[string]*baselineAction
+}
+
+// UpdateOperation defines an interface for an update operation process
+type UpdateOperation interface {
+	GetActivityID() string
+	Identify() error
+	Execute(command types.CommandType, baseline string)
+	Feedback(status types.StatusType, message string, baseline string)
+}
+
+type createUpdateOperation func(*containersUpdateManager, string, interface{}) UpdateOperation
+
+func newOperation(updMgr *containersUpdateManager, activityID string, desiredState interface{}) UpdateOperation {
+	return &operation{
+		updateManager: updMgr,
+		activityID:    activityID,
+		desiredState:  desiredState.(*types.DesiredState),
+	}
+}
+
+// GetActivityID returns the activity ID associated with this operation
+func (o *operation) GetActivityID() string {
+	return o.activityID
+}
+
+// Identify executes the IDENTIFYING phase, triggered with the full desired state for the domain
+func (o *operation) Identify() error {
+	if o.ctx == nil {
+		o.ctx = context.Background()
+	}
+	// TODO compare current vs. desired containers and identify actions
+	return errors.New("Not implemented yet!")
+}
+
+// Execute executes each COMMAND (download, update, activate, etc) phase, triggered per baseline or for all the identified actions
+func (o *operation) Execute(command types.CommandType, baseline string) {
+	switch command {
+	case types.CommandDownload:
+		o.download(baseline)
+	case types.CommandUpdate:
+		o.update(baseline)
+	case types.CommandActivate:
+		o.activate(baseline)
+	case types.CommandRollback:
+		o.rollback(baseline)
+	case types.CommandCleanup:
+		o.cleanup(baseline)
+		if len(o.baselineActions) == 0 {
+			o.updateManager.operation = nil
+			o.Feedback(types.StatusCompleted, "", "")
+		}
+	default:
+		log.Warn("Ignoring unknown command %", command)
+	}
+}
+
+func (o *operation) baselineAction(baseline string) *baselineAction {
+	if baseline == "*" || baseline == "" {
+		o.allActions.baseline = baseline
+		return o.allActions
+	}
+	return o.baselineActions[baseline]
+}
+
+// ActionCreate and ActionRecreate: create new container instance, this will download the container image.
+func (o *operation) download(baseline string) {
+	baselineAction := o.baselineAction(baseline)
+	if baselineAction == nil {
+		o.Feedback(types.BaselineStatusDownloadFailure, "Unknown baseline "+baseline, baseline)
+		return
+	}
+	if baselineAction.status != types.StatusIdentified {
+		o.Feedback(types.BaselineStatusDownloadFailure, "DOWNLOAD possible only after successful IDENTIFICATION phase", baseline)
+		return
+	}
+
+	var lastAction *containerAction
+	var lastActionErr error
+	lastActionMessage := ""
+
+	log.Debug("downloading for baseline %s - starting...", baseline)
+	defer func() {
+		if lastActionErr == nil {
+			o.updateBaselineActionStatus(baselineAction, types.BaselineStatusDownloadSuccess, lastAction, types.ActionStatusDownloadSuccess, lastActionMessage)
+		} else {
+			o.updateBaselineActionStatus(baselineAction, types.BaselineStatusDownloadFailure, lastAction, types.ActionStatusDownloadFailure, lastActionErr.Error())
+		}
+		log.Debug("downloading for baseline %s - done", baseline)
+	}()
+
+	// TODO implement download
+}
+
+// ActionRecreate, ActionDestroy: stops the current container instance.
+// ActionUpdate: update the running container configuration.
+func (o *operation) update(baseline string) {
+	baselineAction := o.baselineAction(baseline)
+	if baselineAction == nil {
+		o.Feedback(types.BaselineStatusUpdateFailure, "Unknown baseline "+baseline, baseline)
+		return
+	}
+	if baselineAction.status != types.BaselineStatusDownloadSuccess {
+		o.Feedback(types.BaselineStatusUpdateFailure, "UPDATE possible only after successful DOWNLOAD phase", baseline)
+		return
+	}
+
+	var lastAction *containerAction
+	var lastActionErr error
+	lastActionMessage := ""
+
+	log.Debug("updating for baseline %s - starting...", baseline)
+	defer func() {
+		if lastActionErr == nil {
+			o.updateBaselineActionStatus(baselineAction, types.BaselineStatusUpdateSuccess, lastAction, types.ActionStatusUpdateSuccess, lastActionMessage)
+		} else {
+			o.updateBaselineActionStatus(baselineAction, types.BaselineStatusUpdateFailure, lastAction, types.ActionStatusUpdateFailure, lastActionErr.Error())
+		}
+		log.Debug("updating for baseline %s - done.", baseline)
+	}()
+
+	// TODO implement update
+}
+
+// ActionCreate, ActionRecreate: starts the newly created container instance (from DOWNLOAD phase).
+// ActionUpdate, ActionCheck: ensure the existing container is running (call start/unpause container).
+func (o *operation) activate(baseline string) {
+	baselineAction := o.baselineAction(baseline)
+	if baselineAction == nil {
+		o.Feedback(types.BaselineStatusActivationFailure, "Unknown baseline "+baseline, baseline)
+		return
+	}
+	if baselineAction.status != types.BaselineStatusUpdateSuccess {
+		o.Feedback(types.BaselineStatusActivationFailure, "ACTIVATE possible only after successful UPDATE phase", baseline)
+		return
+	}
+
+	var lastAction *containerAction
+	var lastActionErr error
+	lastActionMessage := ""
+
+	log.Debug("activating for baseline %s - starting...", baseline)
+	defer func() {
+		if lastActionErr == nil {
+			o.updateBaselineActionStatus(baselineAction, types.BaselineStatusActivationSuccess, lastAction, types.ActionStatusActivationSuccess, lastActionMessage)
+		} else {
+			o.updateBaselineActionStatus(baselineAction, types.BaselineStatusActivationFailure, lastAction, types.ActionStatusActivationFailure, lastActionErr.Error())
+		}
+		log.Debug("activating for baseline %s - done...", baseline)
+	}()
+
+	// TODO implement activate
+}
+
+// ActionCreate: removes the newly created container instance (from DOWNLOAD phase)
+// ActionRecreate: removes the newly created container instance (from DOWNLOAD phase) and restarts the old existing container instance.
+// ActionUpdate: restores the old configuration to the existing container and ensures it is started.
+func (o *operation) rollback(baseline string) {
+	baselineAction := o.baselineAction(baseline)
+	if baselineAction == nil {
+		o.Feedback(types.BaselineStatusRollbackFailure, "Unknown baseline "+baseline, baseline)
+		return
+	}
+	if baselineAction.status != types.BaselineStatusActivationFailure && baselineAction.status != types.BaselineStatusActivationSuccess {
+		o.Feedback(types.BaselineStatusRollbackFailure, "ROLLBACK possible only after ACTIVATION phase", baseline)
+		return
+	}
+
+	var failure bool
+	var lastAction *containerAction
+	var lastActionMessage string
+
+	log.Debug("rollback for baseline %s - starting...", baseline)
+	defer func() {
+		if !failure {
+			o.updateBaselineActionStatus(baselineAction, types.BaselineStatusRollbackSuccess, lastAction, types.ActionStatusUpdateFailure, lastActionMessage)
+		} else {
+			o.updateBaselineActionStatus(baselineAction, types.BaselineStatusRollbackFailure, lastAction, types.ActionStatusUpdateFailure, lastActionMessage)
+		}
+		log.Debug("rollback for baseline %s - done.", baseline)
+	}()
+
+	// TODO implement rollback
+}
+
+// ActionRecreate, ActionDestroy: removes the old existing container instance.
+func (o *operation) cleanup(baseline string) {
+	baselineAction := o.baselineAction(baseline)
+	if baselineAction == nil {
+		o.Feedback(types.BaselineStatusCleanupFailure, "Unknown baseline "+baseline, baseline)
+		return
+	}
+	if baseline == "*" || baseline == "" {
+		for b := range o.baselineActions {
+			delete(o.baselineActions, b)
+		}
+	} else {
+		delete(o.baselineActions, baseline)
+	}
+	log.Debug("cleanup for baseline %s - starting...", baseline)
+
+	// TODO implement cleanup
+
+	o.Feedback(types.BaselineStatusCleanupSuccess, "", baseline)
+	log.Debug("cleanup for baseline %s - done...", baseline)
+}
+
+// Feeback sends desired state feedback responses, baseline parameter is optional
+func (o *operation) Feedback(status types.StatusType, message string, baseline string) {
+	o.updateManager.eventCallback.HandleDesiredStateFeedbackEvent(o.updateManager.domainName, o.activityID, baseline, status, message, o.toFeedbackActions())
+}
+
+func (o *operation) updateBaselineActionStatus(baseline *baselineAction, baselineStatus types.StatusType,
+	action *containerAction, actionStatus types.ActionStatusType, message string) {
+	if action != nil {
+		action.feedbackAction.Status = actionStatus
+		action.feedbackAction.Message = message
+	}
+	baseline.status = baselineStatus
+	o.Feedback(baselineStatus, "", baseline.baseline)
+}
+
+func (o *operation) toFeedbackActions() []*types.Action {
+	if o.allActions == nil {
+		return nil
+	}
+	result := make([]*types.Action, len(o.allActions.actions))
+	for i, action := range o.allActions.actions {
+		result[i] = action.feedbackAction
+	}
+	return result
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 replace github.com/docker/docker => github.com/moby/moby v23.0.3+incompatible
 
-replace github.com/eclipse-kanto/update-manager => github.com/SoftwareDefinedVehicle/kanto-update-manager-fork v0.0.0-20230615081018-07b98f6b8e9e
+replace github.com/eclipse-kanto/update-manager => github.com/SoftwareDefinedVehicle/kanto-update-manager-fork v0.0.0-20230626133425-d048831fa3bf
 
 require (
 	github.com/caarlos0/env/v6 v6.10.1

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.19
 
 replace github.com/docker/docker => github.com/moby/moby v23.0.3+incompatible
 
+replace github.com/eclipse-kanto/update-manager => github.com/SoftwareDefinedVehicle/kanto-update-manager-fork v0.0.0-20230615081018-07b98f6b8e9e
+
 require (
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/containerd/cgroups v1.0.4
@@ -13,6 +15,7 @@ require (
 	github.com/containers/ocicrypt v1.1.6
 	github.com/docker/docker v20.10.24+incompatible
 	github.com/eclipse-kanto/kanto/integration/util v0.0.0-20230103144956-911e45a2bf55
+	github.com/eclipse-kanto/update-manager v0.0.0-00010101000000-000000000000
 	github.com/eclipse/ditto-clients-golang v0.0.0-20220225085802-cf3b306280d3
 	github.com/eclipse/paho.mqtt.golang v1.4.1
 	github.com/gogo/protobuf v1.3.2

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.19
 
 replace github.com/docker/docker => github.com/moby/moby v23.0.3+incompatible
 
-replace github.com/eclipse-kanto/update-manager => github.com/SoftwareDefinedVehicle/kanto-update-manager-fork v0.0.0-20230626133425-d048831fa3bf
-
 require (
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/containerd/cgroups v1.0.4
@@ -15,7 +13,7 @@ require (
 	github.com/containers/ocicrypt v1.1.6
 	github.com/docker/docker v20.10.24+incompatible
 	github.com/eclipse-kanto/kanto/integration/util v0.0.0-20230103144956-911e45a2bf55
-	github.com/eclipse-kanto/update-manager v0.0.0-00010101000000-000000000000
+	github.com/eclipse-kanto/update-manager v0.0.0-20230628072101-b91f0c30e00f
 	github.com/eclipse/ditto-clients-golang v0.0.0-20220225085802-cf3b306280d3
 	github.com/eclipse/paho.mqtt.golang v1.4.1
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
-github.com/SoftwareDefinedVehicle/kanto-update-manager-fork v0.0.0-20230615081018-07b98f6b8e9e h1:ciwnTZIQnxT3pEjBHwT3fs9a8dhC3stmc4wN4TuPYgg=
-github.com/SoftwareDefinedVehicle/kanto-update-manager-fork v0.0.0-20230615081018-07b98f6b8e9e/go.mod h1:wzaUsK5uU6OgdarSTYyV8Wakb3MZ3ifOUR9FNGfoYcA=
+github.com/SoftwareDefinedVehicle/kanto-update-manager-fork v0.0.0-20230626133425-d048831fa3bf h1:eYyWvlk47iZdORmF+LuqD+knGxAnsJE35vyUA3Mhgqs=
+github.com/SoftwareDefinedVehicle/kanto-update-manager-fork v0.0.0-20230626133425-d048831fa3bf/go.mod h1:wzaUsK5uU6OgdarSTYyV8Wakb3MZ3ifOUR9FNGfoYcA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,6 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
-github.com/SoftwareDefinedVehicle/kanto-update-manager-fork v0.0.0-20230626133425-d048831fa3bf h1:eYyWvlk47iZdORmF+LuqD+knGxAnsJE35vyUA3Mhgqs=
-github.com/SoftwareDefinedVehicle/kanto-update-manager-fork v0.0.0-20230626133425-d048831fa3bf/go.mod h1:wzaUsK5uU6OgdarSTYyV8Wakb3MZ3ifOUR9FNGfoYcA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -392,6 +390,8 @@ github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:Htrtb
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eclipse-kanto/kanto/integration/util v0.0.0-20230103144956-911e45a2bf55 h1:a9tYAvpMoDUfcaGL6HZSEOFq82r8VYP+M2dIzTHve2U=
 github.com/eclipse-kanto/kanto/integration/util v0.0.0-20230103144956-911e45a2bf55/go.mod h1:mhkMBNIG+JDz35JAj8JVWMe0/ROpKmk/i6RYHU6Rea4=
+github.com/eclipse-kanto/update-manager v0.0.0-20230628072101-b91f0c30e00f h1:+oeyDIcFCE4cnczhQp7UycS9jZNUuml2x6YccVGjIaY=
+github.com/eclipse-kanto/update-manager v0.0.0-20230628072101-b91f0c30e00f/go.mod h1:wzaUsK5uU6OgdarSTYyV8Wakb3MZ3ifOUR9FNGfoYcA=
 github.com/eclipse/ditto-clients-golang v0.0.0-20220225085802-cf3b306280d3 h1:bfFGs26yNSfhSi6xmnmykB0jZn1Vu5e1/7JA5Wu5aGc=
 github.com/eclipse/ditto-clients-golang v0.0.0-20220225085802-cf3b306280d3/go.mod h1:ey7YwfHSQJsinGkGbgeEgqZA7qJnoB0YiFVTFEY50Jg=
 github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.2.0 h1:Rt8g24XnyGTyglgET/PRUNlrUeu9F5L+7FilkXfZgs0=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
@@ -117,6 +117,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
+github.com/SoftwareDefinedVehicle/kanto-update-manager-fork v0.0.0-20230615081018-07b98f6b8e9e h1:ciwnTZIQnxT3pEjBHwT3fs9a8dhC3stmc4wN4TuPYgg=
+github.com/SoftwareDefinedVehicle/kanto-update-manager-fork v0.0.0-20230615081018-07b98f6b8e9e/go.mod h1:wzaUsK5uU6OgdarSTYyV8Wakb3MZ3ifOUR9FNGfoYcA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
 [#165] Extend daemon configuration with settings for update agent

Dummy implementation of Containers UpdateAgent as Kanto container-management internal service.
- Added UpdateAgentConfig struct, flags and opts for internal containers UpdateAgent service.
- UpdateAgent not fully implemented, just the skeleton. Working implementation will follow with PRs.

Signed-off-by: Stoyan Zoubev [Stoyan.Zoubev@bosch.io](mailto:Stoyan.Zoubev@bosch.io)