### PR TITLE
Move local communication properties outside of the things service

### DIFF
--- a/containerm/daemon/daemon_command.go
+++ b/containerm/daemon/daemon_command.go
@@ -14,6 +14,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func setupCommandFlags(cmd *cobra.Command) {
@@ -83,21 +84,46 @@ func setupCommandFlags(cmd *cobra.Command) {
 	flagSet.BoolVar(&cfg.ThingsConfig.ThingsEnable, "things-enable", cfg.ThingsConfig.ThingsEnable, "Enable the things container management service providing remote containers management and their representation via the Bosch IoT Things service")
 	flagSet.StringVar(&cfg.ThingsConfig.ThingsMetaPath, "things-home-dir", cfg.ThingsConfig.ThingsMetaPath, "Specify the home directory for the things container management service persistent storage")
 	flagSet.StringSliceVar(&cfg.ThingsConfig.Features, "things-features", cfg.ThingsConfig.Features, "Specify the desired Ditto features that will be registered for the containers Ditto thing")
-	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.BrokerURL, "things-conn-broker", cfg.ThingsConfig.ThingsConnectionConfig.BrokerURL, "Specify the MQTT broker URL to connect to")
-	flagSet.Int64Var(&cfg.ThingsConfig.ThingsConnectionConfig.KeepAlive, "things-conn-keep-alive", cfg.ThingsConfig.ThingsConnectionConfig.KeepAlive, "Specify the keep alive duration for the MQTT requests in milliseconds")
-	flagSet.Int64Var(&cfg.ThingsConfig.ThingsConnectionConfig.DisconnectTimeout, "things-conn-disconnect-timeout", cfg.ThingsConfig.ThingsConnectionConfig.DisconnectTimeout, "Specify the disconnection timeout for the MQTT connection in milliseconds")
-	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.ClientUsername, "things-conn-client-username", cfg.ThingsConfig.ThingsConnectionConfig.ClientUsername, "Specify the MQTT client username to authenticate with")
-	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.ClientPassword, "things-conn-client-password", cfg.ThingsConfig.ThingsConnectionConfig.ClientPassword, "Specify the MQTT client password to authenticate with")
-	flagSet.Int64Var(&cfg.ThingsConfig.ThingsConnectionConfig.ConnectTimeout, "things-conn-connect-timeout", cfg.ThingsConfig.ThingsConnectionConfig.ConnectTimeout, "Specify the connect timeout for the MQTT in milliseconds")
-	flagSet.Int64Var(&cfg.ThingsConfig.ThingsConnectionConfig.AcknowledgeTimeout, "things-conn-ack-timeout", cfg.ThingsConfig.ThingsConnectionConfig.AcknowledgeTimeout, "Specify the acknowledgement timeout for the MQTT requests in milliseconds")
-	flagSet.Int64Var(&cfg.ThingsConfig.ThingsConnectionConfig.SubscribeTimeout, "things-conn-sub-timeout", cfg.ThingsConfig.ThingsConnectionConfig.SubscribeTimeout, "Specify the subscribe timeout for the MQTT requests in milliseconds")
-	flagSet.Int64Var(&cfg.ThingsConfig.ThingsConnectionConfig.UnsubscribeTimeout, "things-conn-unsub-timeout", cfg.ThingsConfig.ThingsConnectionConfig.UnsubscribeTimeout, "Specify the unsubscribe timeout for the MQTT requests in milliseconds")
+
+	// init local communication flags
+	flagSet.StringVar(&cfg.LocalConnection.BrokerURL, "conn-broker-url", cfg.LocalConnection.BrokerURL, "Specify the MQTT broker URL to connect to")
+	flagSet.StringVar(&cfg.LocalConnection.KeepAlive, "conn-keep-alive", cfg.LocalConnection.KeepAlive, "Specify the keep alive duration for the MQTT requests as duration string")
+	flagSet.StringVar(&cfg.LocalConnection.DisconnectTimeout, "conn-disconnect-timeout", cfg.LocalConnection.DisconnectTimeout, "Specify the disconnection timeout for the MQTT connection as duration string")
+	flagSet.StringVar(&cfg.LocalConnection.ClientUsername, "conn-client-username", cfg.LocalConnection.ClientUsername, "Specify the MQTT client username to authenticate with")
+	flagSet.StringVar(&cfg.LocalConnection.ClientPassword, "conn-client-password", cfg.LocalConnection.ClientPassword, "Specify the MQTT client password to authenticate with")
+	flagSet.StringVar(&cfg.LocalConnection.ConnectTimeout, "conn-connect-timeout", cfg.LocalConnection.ConnectTimeout, "Specify the connect timeout for the MQTT as duration string")
+	flagSet.StringVar(&cfg.LocalConnection.AcknowledgeTimeout, "conn-ack-timeout", cfg.LocalConnection.AcknowledgeTimeout, "Specify the acknowledgement timeout for the MQTT requests as duration string")
+	flagSet.StringVar(&cfg.LocalConnection.SubscribeTimeout, "conn-sub-timeout", cfg.LocalConnection.SubscribeTimeout, "Specify the subscribe timeout for the MQTT requests as duration string")
+	flagSet.StringVar(&cfg.LocalConnection.UnsubscribeTimeout, "conn-unsub-timeout", cfg.LocalConnection.UnsubscribeTimeout, "Specify the unsubscribe timeout for the MQTT requests as duration string")
+
+	// init tls support
+	if cfg.LocalConnection.Transport == nil {
+		cfg.LocalConnection.Transport = &tlsConfig{}
+	}
+	flagSet.StringVar(&cfg.LocalConnection.Transport.RootCA, "conn-root-ca", cfg.LocalConnection.Transport.RootCA, "Specify the PEM encoded CA certificates file")
+	flagSet.StringVar(&cfg.LocalConnection.Transport.ClientCert, "conn-client-cert", cfg.LocalConnection.Transport.ClientCert, "Specify the PEM encoded certificate file to authenticate to the MQTT server/broker")
+	flagSet.StringVar(&cfg.LocalConnection.Transport.ClientKey, "conn-client-key", cfg.LocalConnection.Transport.ClientKey, "Specify the PEM encoded unencrypted private key file to authenticate to the MQTT server/broker")
+
+	//TODO remove in M5
+	setupDeprecatedCommandFlags(flagSet)
+}
+
+func setupDeprecatedCommandFlags(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.BrokerURL, "things-conn-broker", cfg.ThingsConfig.ThingsConnectionConfig.BrokerURL, "DEPRECATED Specify the MQTT broker URL to connect to")
+	flagSet.Int64Var(&cfg.ThingsConfig.ThingsConnectionConfig.KeepAlive, "things-conn-keep-alive", cfg.ThingsConfig.ThingsConnectionConfig.KeepAlive, "DEPRECATED Specify the keep alive duration for the MQTT requests in milliseconds")
+	flagSet.Int64Var(&cfg.ThingsConfig.ThingsConnectionConfig.DisconnectTimeout, "things-conn-disconnect-timeout", cfg.ThingsConfig.ThingsConnectionConfig.DisconnectTimeout, "DEPRECATED Specify the disconnection timeout for the MQTT connection in milliseconds")
+	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.ClientUsername, "things-conn-client-username", cfg.ThingsConfig.ThingsConnectionConfig.ClientUsername, "DEPRECATED Specify the MQTT client username to authenticate with")
+	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.ClientPassword, "things-conn-client-password", cfg.ThingsConfig.ThingsConnectionConfig.ClientPassword, "DEPRECATED Specify the MQTT client password to authenticate with")
+	flagSet.Int64Var(&cfg.ThingsConfig.ThingsConnectionConfig.ConnectTimeout, "things-conn-connect-timeout", cfg.ThingsConfig.ThingsConnectionConfig.ConnectTimeout, "DEPRECATED Specify the connect timeout for the MQTT in milliseconds")
+	flagSet.Int64Var(&cfg.ThingsConfig.ThingsConnectionConfig.AcknowledgeTimeout, "things-conn-ack-timeout", cfg.ThingsConfig.ThingsConnectionConfig.AcknowledgeTimeout, "DEPRECATED Specify the acknowledgement timeout for the MQTT requests in milliseconds")
+	flagSet.Int64Var(&cfg.ThingsConfig.ThingsConnectionConfig.SubscribeTimeout, "things-conn-sub-timeout", cfg.ThingsConfig.ThingsConnectionConfig.SubscribeTimeout, "DEPRECATED Specify the subscribe timeout for the MQTT requests in milliseconds")
+	flagSet.Int64Var(&cfg.ThingsConfig.ThingsConnectionConfig.UnsubscribeTimeout, "things-conn-unsub-timeout", cfg.ThingsConfig.ThingsConnectionConfig.UnsubscribeTimeout, "DEPRECATED Specify the unsubscribe timeout for the MQTT requests in milliseconds")
 
 	// init tls support
 	if cfg.ThingsConfig.ThingsConnectionConfig.Transport == nil {
 		cfg.ThingsConfig.ThingsConnectionConfig.Transport = &tlsConfig{}
 	}
-	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.RootCA, "things-conn-root-ca", cfg.ThingsConfig.ThingsConnectionConfig.Transport.RootCA, "Specify the PEM encoded CA certificates file")
-	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientCert, "things-conn-client-cert", cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientCert, "Specify the PEM encoded certificate file to authenticate to the MQTT server/broker")
-	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientKey, "things-conn-client-key", cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientKey, "Specify the PEM encoded unencrypted private key file to authenticate to the MQTT server/broker")
+	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.RootCA, "things-conn-root-ca", cfg.ThingsConfig.ThingsConnectionConfig.Transport.RootCA, "DEPRECATED Specify the PEM encoded CA certificates file")
+	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientCert, "things-conn-client-cert", cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientCert, "DEPRECATED Specify the PEM encoded certificate file to authenticate to the MQTT server/broker")
+	flagSet.StringVar(&cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientKey, "things-conn-client-key", cfg.ThingsConfig.ThingsConnectionConfig.Transport.ClientKey, "DEPRECATED Specify the PEM encoded unencrypted private key file to authenticate to the MQTT server/broker")
 }

--- a/containerm/daemon/daemon_config.go
+++ b/containerm/daemon/daemon_config.go
@@ -34,6 +34,8 @@ type config struct {
 	GrpcServerConfig *grpcServerConfig `json:"grpc_server,omitempty"`
 
 	ThingsConfig *thingsConfig `json:"things,omitempty"`
+
+	LocalConnection *localConnectionConfig `json:"connection,omitempty"`
 }
 
 // container mgr config
@@ -149,6 +151,21 @@ type thingsConfig struct {
 	ThingsConnectionConfig *thingsConnectionConfig `json:"connection,omitempty"`
 }
 
+// local connection config
+type localConnectionConfig struct {
+	BrokerURL          string     `json:"broker_url,omitempty"`
+	KeepAlive          string     `json:"keep_alive,omitempty"`
+	DisconnectTimeout  string     `json:"disconnect_timeout,omitempty"`
+	ClientUsername     string     `json:"client_username,omitempty"`
+	ClientPassword     string     `json:"client_password,omitempty"`
+	ConnectTimeout     string     `json:"connect_timeout,omitempty"`
+	AcknowledgeTimeout string     `json:"acknowledge_timeout,omitempty"`
+	SubscribeTimeout   string     `json:"subscribe_timeout,omitempty"`
+	UnsubscribeTimeout string     `json:"unsubscribe_timeout,omitempty"`
+	Transport          *tlsConfig `json:"transport,omitempty"`
+}
+
+// TODO Remove in M5
 // things service connection config
 type thingsConnectionConfig struct {
 	BrokerURL          string     `json:"broker_url,omitempty"`

--- a/containerm/daemon/daemon_config_default.go
+++ b/containerm/daemon/daemon_config_default.go
@@ -75,18 +75,20 @@ const (
 	grpcServerNetworkProtocolDefault = "unix"
 	grpcServerAddressPathDefault     = "/run/container-management/container-management.sock"
 
-	// default things connection config
-	thingsEnableDefault                      = true
-	thingsMetaPathDefault                    = managerMetaPathDefault
-	thingsConnectionBrokerURLDefault         = "tcp://localhost:1883"
-	thingsConnectionKeepAliveDefault         = 20000
-	thingsConnectionDisconnectTimeoutDefault = 250
-	thingsConnectionClientUsername           = ""
-	thingsConnectionClientPassword           = ""
-	thingsConnectTimeoutTimeoutDefault       = 30000
-	thingsAcknowledgeTimeoutDefault          = 15000
-	thingsSubscribeTimeoutDefault            = 15000
-	thingsUnsubscribeTimeoutDefault          = 5000
+	// default things config
+	thingsEnableDefault   = true
+	thingsMetaPathDefault = managerMetaPathDefault
+
+	// default local connection config
+	connectionBrokerURLDefault         = "tcp://localhost:1883"
+	connectionKeepAliveDefault         = "20s"
+	connectionDisconnectTimeoutDefault = "250ms"
+	connectionClientUsername           = ""
+	connectionClientPassword           = ""
+	connectTimeoutTimeoutDefault       = "30s"
+	acknowledgeTimeoutDefault          = "15s"
+	subscribeTimeoutDefault            = "15s"
+	unsubscribeTimeoutDefault          = "5s"
 
 	// default deployment config
 	deploymentEnableDefault   = true
@@ -159,15 +161,15 @@ func getDefaultInstance() *config {
 			ThingsMetaPath: thingsMetaPathDefault,
 			Features:       thingsServiceFeaturesDefault,
 			ThingsConnectionConfig: &thingsConnectionConfig{
-				BrokerURL:          thingsConnectionBrokerURLDefault,
-				KeepAlive:          thingsConnectionKeepAliveDefault,
-				DisconnectTimeout:  thingsConnectionDisconnectTimeoutDefault,
-				ClientUsername:     thingsConnectionClientUsername,
-				ClientPassword:     thingsConnectionClientPassword,
-				ConnectTimeout:     thingsConnectTimeoutTimeoutDefault,
-				AcknowledgeTimeout: thingsAcknowledgeTimeoutDefault,
-				SubscribeTimeout:   thingsSubscribeTimeoutDefault,
-				UnsubscribeTimeout: thingsUnsubscribeTimeoutDefault,
+				BrokerURL:          connectionBrokerURLDefault,
+				KeepAlive:          20000,
+				DisconnectTimeout:  250,
+				ClientUsername:     connectionClientUsername,
+				ClientPassword:     connectionClientPassword,
+				ConnectTimeout:     30000,
+				AcknowledgeTimeout: 15000,
+				SubscribeTimeout:   15000,
+				UnsubscribeTimeout: 5000,
 			},
 		},
 		DeploymentManagerConfig: &deploymentManagerConfig{
@@ -175,6 +177,17 @@ func getDefaultInstance() *config {
 			DeploymentMode:     deploymentModeDefault,
 			DeploymentMetaPath: deploymentMetaPathDefault,
 			DeploymentCtrPath:  deploymentCtrPathDefault,
+		},
+		LocalConnection: &localConnectionConfig{
+			BrokerURL:          connectionBrokerURLDefault,
+			KeepAlive:          connectionKeepAliveDefault,
+			DisconnectTimeout:  connectionDisconnectTimeoutDefault,
+			ClientUsername:     connectionClientUsername,
+			ClientPassword:     connectionClientPassword,
+			ConnectTimeout:     connectTimeoutTimeoutDefault,
+			AcknowledgeTimeout: acknowledgeTimeoutDefault,
+			SubscribeTimeout:   subscribeTimeoutDefault,
+			UnsubscribeTimeout: unsubscribeTimeoutDefault,
 		},
 	}
 }

--- a/containerm/daemon/daemon_test.go
+++ b/containerm/daemon/daemon_test.go
@@ -405,6 +405,54 @@ func TestSetCommandFlags(t *testing.T) {
 			flag:         "deployment-ctr-dir",
 			expectedType: reflect.String.String(),
 		},
+		"test_flags-conn-broker": {
+			flag:         "conn-broker-url",
+			expectedType: reflect.String.String(),
+		},
+		"test_flags-conn-keep-alive": {
+			flag:         "conn-keep-alive",
+			expectedType: reflect.String.String(),
+		},
+		"test_flags-conn-disconnect-timeout": {
+			flag:         "conn-disconnect-timeout",
+			expectedType: reflect.String.String(),
+		},
+		"test_flags-conn-client-username": {
+			flag:         "conn-client-username",
+			expectedType: reflect.String.String(),
+		},
+		"test_flags-conn-client-password": {
+			flag:         "conn-client-password",
+			expectedType: reflect.String.String(),
+		},
+		"test_flags-conn-connect-timeout": {
+			flag:         "conn-connect-timeout",
+			expectedType: reflect.String.String(),
+		},
+		"test_flags-conn-ack-timeout": {
+			flag:         "conn-ack-timeout",
+			expectedType: reflect.String.String(),
+		},
+		"test_flags-conn-sub-timeout": {
+			flag:         "conn-sub-timeout",
+			expectedType: reflect.String.String(),
+		},
+		"test_flags-conn-unsub-timeout": {
+			flag:         "conn-unsub-timeout",
+			expectedType: reflect.String.String(),
+		},
+		"test_flags-conn-root-ca": {
+			flag:         "conn-root-ca",
+			expectedType: reflect.String.String(),
+		},
+		"test_flags-conn-client-cert": {
+			flag:         "conn-client-cert",
+			expectedType: reflect.String.String(),
+		},
+		"test_flags-conn-client-key": {
+			flag:         "conn-client-key",
+			expectedType: reflect.String.String(),
+		},
 	}
 
 	for testName, testCase := range tests {
@@ -499,7 +547,7 @@ func TestParseRegistryConfigs(t *testing.T) {
 			t.Errorf("tls config client key not parsed correctly")
 		}
 		if tlsCfg.Transport.RootCA != "/my/secure/path/ca.crt" {
-			t.Errorf("tls config client roor ca not parsed correctly")
+			t.Errorf("tls config client root ca not parsed correctly")
 		}
 		if tlsCfg.Credentials != nil {
 			t.Errorf("tls config credentials must be nil after parsing")
@@ -511,7 +559,7 @@ func TestParseRegistryConfigs(t *testing.T) {
 			t.Errorf("basic auth config missing after parse")
 		}
 		if basicAuthTLS.IsInsecure {
-			t.Errorf("basic auth with tls isInsecure not parsed correclty")
+			t.Errorf("basic auth with tls isInsecure not parsed correctly")
 		}
 		if basicAuthTLS.Transport.ClientCert != "/my/secure/path/client.cert" {
 			t.Errorf("basic auth with tls config client cert not parsed correctly")
@@ -520,7 +568,7 @@ func TestParseRegistryConfigs(t *testing.T) {
 			t.Errorf("basic auth with tls config client key not parsed correctly")
 		}
 		if basicAuthTLS.Transport.RootCA != "/my/secure/path/ca.crt" {
-			t.Errorf("basic auth with tls config client roor ca not parsed correctly")
+			t.Errorf("basic auth with tls config client root ca not parsed correctly")
 		}
 		if basicAuthTLS.Credentials.UserID != "my-username" {
 			t.Errorf("basic auth with tls config username not parsed correctly")

--- a/containerm/pkg/testutil/config/daemon-config.json
+++ b/containerm/pkg/testutil/config/daemon-config.json
@@ -69,5 +69,16 @@
     "mode": "update",
     "home_dir": "/var/lib/container-management",
     "ctr_dir": "/etc/container-management/containers"
+  },
+  "connection": {
+    "broker_url": "tcp://localhost:1883",
+    "keep_alive": "20s",
+    "disconnect_timeout": "250ms",
+    "client_username": "",
+    "client_password": "",
+    "connect_timeout": "30s",
+    "acknowledge_timeout": "15s",
+    "subscribe_timeout": "15s",
+    "unsubscribe_timeout": "5s"
   }
 }


### PR DESCRIPTION
[#169] Local communication properties should be outside of the things service

Signed-off-by: Kristiyan Gostev <kristiyan.gostev@bosch.com>