### PR TITLE
Remove command should accept more than one container ID

### DIFF
--- a/containerm/cli/cli_command_ctrs_remove.go
+++ b/containerm/cli/cli_command_ctrs_remove.go
@@ -35,9 +35,9 @@ type removeConfig struct {
 func (cc *removeCmd) init(cli *cli) {
 	cc.cli = cli
 	cc.cmd = &cobra.Command{
-		Use:   "remove <container-id/s>",
-		Short: "Remove a container/s.",
-		Long:  "Remove a container and frees the associated resources.",
+		Use:   "remove <container-id> ...",
+		Short: "Remove one or more containers.",
+		Long:  "Remove one or more containers and frees the associated resources.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cc.run(args)
 		},

--- a/containerm/cli/cli_command_ctrs_remove.go
+++ b/containerm/cli/cli_command_ctrs_remove.go
@@ -59,21 +59,21 @@ func (cc *removeCmd) run(args []string) error {
 			return err
 		}
 		return cc.cli.gwManClient.Remove(ctx, ctr.ID, cc.config.force)
-	} else {
-		for _, arg := range args {
-			ctr, err = utilcli.ValidateContainerByNameArgsSingle(ctx, []string{arg}, cc.config.name, cc.cli.gwManClient)
-			if err == nil {
-				if err = cc.cli.gwManClient.Remove(ctx, ctr.ID, cc.config.force); err != nil {
-					errs.Append(err)
-				}
-			} else {
+	}
+	for _, arg := range args {
+		ctr, err = utilcli.ValidateContainerByNameArgsSingle(ctx, []string{arg}, cc.config.name, cc.cli.gwManClient)
+		if err == nil {
+			if err = cc.cli.gwManClient.Remove(ctx, ctr.ID, cc.config.force); err != nil {
 				errs.Append(err)
 			}
-		}
-		if errs.Size() > 0 {
-			return errors.New(errs.ErrorWithMessage("containers couldn't be removed due to the following reasons: "))
+		} else {
+			errs.Append(err)
 		}
 	}
+	if errs.Size() > 0 {
+		return errors.New(errs.ErrorWithMessage("containers couldn't be removed due to the following reasons: "))
+	}
+
 	return nil
 }
 

--- a/containerm/util/cli/args_util.go
+++ b/containerm/util/cli/args_util.go
@@ -32,7 +32,7 @@ func ValidateContainerByNameArgsSingle(ctx context.Context, args []string, provi
 		err       error
 	)
 	// parse parameters
-	if len(args) == 1 {
+	if len(args) >= 1 {
 		if container, err = kantoCMClient.Get(ctx, args[0]); err != nil {
 			return nil, err
 		} else if container == nil {

--- a/containerm/util/error/error_util.go
+++ b/containerm/util/error/error_util.go
@@ -34,6 +34,10 @@ func (m *CompoundError) Size() int {
 
 // Error returns the combined error messages.
 func (m *CompoundError) Error() string {
+	return m.ErrorWithMessage(fmt.Sprintf("%d errors:", len(m.errs)))
+}
+
+func (m *CompoundError) ErrorWithMessage(message string) string {
 	if len(m.errs) == 0 {
 		return fmt.Sprintf("no error")
 	}
@@ -46,5 +50,6 @@ func (m *CompoundError) Error() string {
 	for i, err := range m.errs {
 		serrs[i] = fmt.Sprintf("* %s", err)
 	}
-	return fmt.Sprintf("%d errors:\n\n%s", len(m.errs), strings.Join(serrs, "\n"))
+
+	return fmt.Sprintf("%s\n\n%s", message, strings.Join(serrs, "\n"))
 }

--- a/containerm/util/error/error_util.go
+++ b/containerm/util/error/error_util.go
@@ -37,6 +37,7 @@ func (m *CompoundError) Error() string {
 	return m.ErrorWithMessage(fmt.Sprintf("%d errors:", len(m.errs)))
 }
 
+// ErrorWithMessage returns combined error messages with a custom message.
 func (m *CompoundError) ErrorWithMessage(message string) string {
 	if len(m.errs) == 0 {
 		return fmt.Sprintf("no error")

--- a/integration/testdata/remove-help.golden
+++ b/integration/testdata/remove-help.golden
@@ -1,10 +1,11 @@
 Remove a container and frees the associated resources.
 
 Usage:
-  kanto-cm remove <container-id>
+  kanto-cm remove <container-id/s>
 
 Examples:
-remove <container-id>
+ remove <container-id>
+ remove <container-id> <container-id> 
  remove --name <container-name>
  remove -n <container-name>
 

--- a/integration/testdata/remove-help.golden
+++ b/integration/testdata/remove-help.golden
@@ -1,7 +1,7 @@
-Remove a container and frees the associated resources.
+Remove one or more containers and frees the associated resources.
 
 Usage:
-  kanto-cm remove <container-id/s>
+  kanto-cm remove <container-id> ...
 
 Examples:
  remove <container-id>


### PR DESCRIPTION
[#210] Changed remove command to accept more than one container.
Signed-off-by: Daniel Milchev fixed-term.daniel.milchev@bosch.io